### PR TITLE
Dean block page

### DIFF
--- a/src/lib/components/descriptionlist.svelte
+++ b/src/lib/components/descriptionlist.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
+
 	type DescriptionItem = {
 		key: string;
-		value: string;
+		value: string | Snippet;
 	};
 
 	interface Props {
@@ -17,7 +19,7 @@
 			class="flex flex-wrap items-center justify-between gap-x-4 border-b border-mineShaft-900 py-3 *:grow last:border-none"
 		>
 			<dt class="caption">{item.key}</dt>
-			<dd class="text-right tabular-nums">{item.value}</dd>
+			<dd class="text-balance break-all text-right tabular-nums">{item.value}</dd>
 		</div>
 	{/each}
 </dl>

--- a/src/lib/components/descriptionlist/dl.svelte
+++ b/src/lib/components/descriptionlist/dl.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import Dlrow from './dlrow.svelte';
+
+	type DescriptionItem = {
+		key: string;
+		value: string;
+	};
+
+	interface Props {
+		items?: DescriptionItem[];
+		children?: Snippet;
+	}
+
+	let props: Props = $props();
+</script>
+
+<dl class="@container">
+	{#if props.items}
+		{#each props.items as item}
+			<Dlrow title={item.key}>
+				{item.value}
+			</Dlrow>
+		{/each}
+	{:else if props.children}
+		{@render props.children()}
+	{/if}
+</dl>

--- a/src/lib/components/descriptionlist/dlrow.svelte
+++ b/src/lib/components/descriptionlist/dlrow.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		title: string;
+		children: Snippet;
+	}
+	let { title, children }: Props = $props();
+</script>
+
+<div
+	class="flex flex-wrap items-center justify-between gap-x-4 border-b border-mineShaft-900 py-3 last:border-none @xs:flex-nowrap"
+>
+	<dt class="caption self-start text-nowrap">{title}</dt>
+	<dd class="grow text-balance break-all text-right tabular-nums">{@render children()}</dd>
+</div>

--- a/src/lib/components/descriptionlist/index.ts
+++ b/src/lib/components/descriptionlist/index.ts
@@ -1,0 +1,2 @@
+export { default as DL } from './dl.svelte';
+export { default as DLRow } from './dlrow.svelte';

--- a/src/lib/components/elements/account.svelte
+++ b/src/lib/components/elements/account.svelte
@@ -11,7 +11,7 @@
 	import { page } from '$app/stores';
 
 	interface Props extends HTMLAnchorAttributes {
-		name: string;
+		name: Name | string;
 		contract?: boolean;
 		children?: Snippet;
 		preview?: boolean;
@@ -50,7 +50,10 @@
 
 <a
 	href={path}
-	class={cn('focus-visible:outline focus-visible:outline-solar-500 ', props.class)}
+	class={cn(
+		'text-skyBlue-500 hover:text-skyBlue-400 focus-visible:outline focus-visible:outline-solar-500 ',
+		props.class
+	)}
 	use:melt={$trigger}
 >
 	{#if children}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,3 +1,5 @@
+import { languageTag } from '$lib/paraglide/runtime';
+import { goto as svelteGoto } from '$app/navigation';
 import { ABI, Asset, type NameType } from '@wharfkit/antelope';
 import yaml from 'yaml';
 
@@ -99,3 +101,11 @@ export function isSameToken(token1?: TokenKeyParams, token2?: TokenKeyParams): b
 		String(token1.symbol) === String(token2.symbol)
 	);
 }
+
+/**
+ * Adds the language tag prefix to the built-in svelte goto()
+ * @example "/eos/account/123" => "/en/eos/account/123"
+ */
+export const goto: typeof svelteGoto = (url, opts = {}) => {
+	return svelteGoto(`/${languageTag()}${url}`, opts);
+};

--- a/src/routes/[network]/(explorer)/block/[number]/+layout.svelte
+++ b/src/routes/[network]/(explorer)/block/[number]/+layout.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { Stack } from '$lib/components/layout/index.js';
 	import PillGroup from '$lib/components/navigation/pillgroup.svelte';
+	import type { UnicoveContext } from '$lib/state/client.svelte.js';
+	import { getContext } from 'svelte';
 
 	const { children, data } = $props();
+
+	const { settings } = getContext<UnicoveContext>('state');
 
 	const tabOptions = $derived.by(() => {
 		let urlBase = `/${data.network}/block/${data.number}`;
@@ -23,6 +28,10 @@
 	);
 </script>
 
-<PillGroup {options} />
+<Stack class="@container">
+	{#if settings.data.debugMode}
+		<PillGroup {options} />
+	{/if}
 
-{@render children()}
+	{@render children()}
+</Stack>

--- a/src/routes/[network]/(explorer)/block/[number]/+layout.ts
+++ b/src/routes/[network]/(explorer)/block/[number]/+layout.ts
@@ -1,16 +1,16 @@
 import type { Load } from '@sveltejs/kit';
 import * as m from '$lib/paraglide/messages.js';
-import { TimePointSec, Transaction } from '@wharfkit/antelope';
+import { API, TimePointSec, Transaction } from '@wharfkit/antelope';
 import { languageTag } from '$lib/paraglide/runtime';
 
 export const load: Load = async ({ fetch, params, parent }) => {
 	const { network } = await parent();
 	const response = await fetch(`/${params.network}/api/block/${params.number}`);
 	const json = await response.json();
-	const block = json.block;
+	const block = json.block as API.v1.GetBlockResponse;
 	// Create metadata for the page
 	const actions = block.transactions.reduce(
-		(acc: number, tx: { trx: { transaction: Transaction } }) => {
+		(acc: number, tx: { trx: { transaction?: Transaction } }) => {
 			if (!tx.trx.transaction) {
 				return acc;
 			}
@@ -34,6 +34,7 @@ export const load: Load = async ({ fetch, params, parent }) => {
 		title,
 		subtitle: date.toLocaleString(languageTag()),
 		block,
+		actions,
 		network: params.network,
 		height: Number(params.number),
 		pageMetaTags: {

--- a/src/routes/[network]/(explorer)/block/[number]/+layout.ts
+++ b/src/routes/[network]/(explorer)/block/[number]/+layout.ts
@@ -1,30 +1,40 @@
-import type { Load } from '@sveltejs/kit';
+import type { LayoutLoad } from './$types';
 import * as m from '$lib/paraglide/messages.js';
-import { API, TimePointSec, Transaction } from '@wharfkit/antelope';
-import { languageTag } from '$lib/paraglide/runtime';
+import { API, TimePoint } from '@wharfkit/antelope';
 
-export const load: Load = async ({ fetch, params, parent }) => {
+export const load: LayoutLoad = async ({ fetch, params, parent }) => {
 	const { network } = await parent();
 	const response = await fetch(`/${params.network}/api/block/${params.number}`);
 	const json = await response.json();
 	const block = json.block as API.v1.GetBlockResponse;
-	// Create metadata for the page
-	const actions = block.transactions.reduce(
-		(acc: number, tx: { trx: { transaction?: Transaction } }) => {
-			if (!tx.trx.transaction) {
-				return acc;
-			}
-			return acc + tx.trx.transaction.actions.length;
+
+	const { cpuCount, netCount, actionCount } = block.transactions.reduce(
+		(acc, tx) => {
+			acc.cpuCount += Number(tx.cpu_usage_us);
+			acc.netCount += Number(tx.net_usage_words) * 8;
+			acc.actionCount += tx.trx.transaction ? tx.trx.transaction.actions.length : 0;
+			return acc;
 		},
-		0
+		{ cpuCount: 0, netCount: 0, actionCount: 0 }
 	);
-	const date = TimePointSec.from(block.timestamp).toDate();
+
+	const details = {
+		totalCpu: cpuCount,
+		totalNet: netCount,
+		totalActions: actionCount,
+		blockId: String(block.id),
+		blockNumber: Number(block.block_num),
+		blockProducer: block.producer
+	};
+
+	const date = TimePoint.from(block.timestamp).toDate();
+
 	const description = m.block_height_numbered_description({
 		height: String(params.number),
 		producer: block.producer,
 		timestamp: date,
 		transactions: block.transactions.length,
-		actions
+		actions: actionCount
 	});
 
 	const title = m.block_height_numbered({ height: Number(params.number) });
@@ -32,9 +42,9 @@ export const load: Load = async ({ fetch, params, parent }) => {
 	return {
 		number: params.number,
 		title,
-		subtitle: date.toLocaleString(languageTag()),
+		subtitle: date.toISOString(),
 		block,
-		actions,
+		details,
 		network: params.network,
 		height: Number(params.number),
 		pageMetaTags: {

--- a/src/routes/[network]/(explorer)/block/[number]/+page.svelte
+++ b/src/routes/[network]/(explorer)/block/[number]/+page.svelte
@@ -7,7 +7,14 @@
 	import ChevronRight from 'lucide-svelte/icons/chevron-right';
 	import { truncateCenter } from '$lib/utils';
 
-	const { data } = $props();
+	let { data } = $props();
+
+	const details = $derived([
+		{ key: 'Block Number', value: data.block.block_num },
+		{ key: 'Producer Name', value: data.block.producer },
+		{ key: 'Total Actions', value: data.actions },
+		{ key: 'Block ID', value: data.block.id }
+	]);
 
 	const totalTransactionCount = $derived(
 		data.block.transactions.filter(
@@ -37,7 +44,7 @@
 	});
 </script>
 
-<div class="gap-6 text-nowrap *:mb-6 *:w-full *:break-inside-avoid last:*:mb-0 @4xl:columns-2">
+<MultiCard>
 	<Card class="text-muted gap-0 bg-transparent px-2 py-0 sm:px-5">
 		<div class="flex items-center gap-2 py-2 text-white">
 			<ArrowRightLeft class="size-4" />
@@ -124,4 +131,60 @@
 			>
 		</Cluster>
 	</Card>
-</div>
+</MultiCard>
+
+
+<Stack class="@container">
+	<!-- <Pillgroup /> -->
+	<MultiCard>
+		{#if data.block.transactions}
+			{@const transactions = data.block.transactions}
+			<Stack id="transactions">
+				<h2 class="h3 flex items-center gap-2">
+					<ArrowLeftRight class="size-5" />
+					{transactions.length}
+					{transactions.length > 1 ? 'Transactions' : 'Transaction'}
+				</h2>
+				<table class="table-styles">
+					<thead>
+						<tr>
+							<th>Transaction</th>
+							<th>Actions</th>
+							<th>CPU</th>
+							<th>NET</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each transactions as transaction}
+							<tr>
+								<td><Transaction id={transaction.trx.id} /></td>
+								<td>{transaction.trx.transaction?.actions.length}</td>
+								<td>{transaction.cpu_usage_us}</td>
+								<td>{transaction.net_usage_words}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</Stack>
+		{/if}
+
+		<Stack id="details">
+			<h2 class="h3 flex items-center gap-2">Block Details</h2>
+			<Descriptionlist items={details} />
+			<Switcher>
+				{#if data.height > 1}
+					<Button variant="secondary" href="/{data.network}/block/{Number(data.height) - 1}">
+						{m.block_height_numbered({ height: Number(data.height) - 1 })}
+					</Button>
+				{/if}
+				<Button variant="secondary" href="/{data.network}/block/{Number(data.height) + 1}">
+					{m.block_height_numbered({ height: Number(data.height) + 1 })}
+				</Button>
+			</Switcher>
+		</Stack>
+
+		<Code>
+			{JSON.stringify(data.block, null, 2)}
+		</Code>
+	</MultiCard>
+</Stack>

--- a/src/routes/[network]/(explorer)/block/[number]/+page.svelte
+++ b/src/routes/[network]/(explorer)/block/[number]/+page.svelte
@@ -3,7 +3,7 @@
 	import TransactionText from '$lib/components/elements/transaction.svelte';
 	import AccountText from '$lib/components/elements/account.svelte';
 	import Button from '$lib/components/button/button.svelte';
-	import ArrowLeftRight from 'lucide-svelte/icons/arrow-left-right';
+	import { ArrowLeftRight, ArrowRight, ArrowLeft } from 'lucide-svelte';
 	import { DL, DLRow } from '$lib/components/descriptionlist/index.js';
 
 	let { data } = $props();
@@ -71,11 +71,15 @@
 		<Switcher>
 			{#if data.height > 1}
 				<Button href="/{data.network}/block/{Number(data.height) - 1}" variant="secondary">
-					← Previous Block
+					<span class="inline-flex items-center gap-1">
+						<ArrowLeft class="size-4" /> Previous Block
+					</span>
 				</Button>
 			{/if}
 			<Button href="/{data.network}/block/{Number(data.height) + 1}" variant="secondary">
-				Next Block →
+				<span class="inline-flex items-center gap-1">
+					Next Block <ArrowRight class="size-4" />
+				</span>
 			</Button>
 		</Switcher>
 	</Stack>

--- a/src/routes/[network]/(explorer)/block/[number]/+page.svelte
+++ b/src/routes/[network]/(explorer)/block/[number]/+page.svelte
@@ -1,190 +1,82 @@
 <script lang="ts">
-	import { Card, Cluster } from '$lib/components/layout';
-	import TransactionElement from '$lib/components/elements/transaction.svelte';
-	import { Transaction } from '@wharfkit/antelope';
+	import { Stack, MultiCard, Switcher } from '$lib/components/layout';
+	import TransactionText from '$lib/components/elements/transaction.svelte';
+	import AccountText from '$lib/components/elements/account.svelte';
 	import Button from '$lib/components/button/button.svelte';
-	import ArrowRightLeft from 'lucide-svelte/icons/arrow-right-left';
-	import ChevronRight from 'lucide-svelte/icons/chevron-right';
-	import { truncateCenter } from '$lib/utils';
+	import ArrowLeftRight from 'lucide-svelte/icons/arrow-left-right';
+	import { DL, DLRow } from '$lib/components/descriptionlist/index.js';
 
 	let { data } = $props();
-
-	const details = $derived([
-		{ key: 'Block Number', value: data.block.block_num },
-		{ key: 'Producer Name', value: data.block.producer },
-		{ key: 'Total Actions', value: data.actions },
-		{ key: 'Block ID', value: data.block.id }
-	]);
-
-	const totalTransactionCount = $derived(
-		data.block.transactions.filter(
-			(item: { trx: { transaction: Transaction } }) => item.trx?.transaction
-		).length
-	);
-
-	const deails: string[][] = $derived.by(() => {
-		const items: string[][] = [];
-		const result = data.block.transactions.reduce(
-			(
-				acc: { cpuCount: number; netCount: number; actionCount: number },
-				tx: { cpu_usage_us: number; net_usage_words: number; trx: { transaction: Transaction } }
-			) => {
-				acc.cpuCount += tx.cpu_usage_us;
-				acc.netCount += tx.net_usage_words * 8;
-				acc.actionCount += tx.trx.transaction ? tx.trx.transaction.actions.length : 0;
-				return acc;
-			},
-			{ cpuCount: 0, netCount: 0, actionCount: 0 }
-		);
-		items.push(['Total Block CPU', `${result.cpuCount} μs`]);
-		items.push(['Total Block NET', `${result.netCount} Bytes`]);
-		items.push(['Total Actions', `${result.actionCount}`]);
-		items.push(['Block ID', `${data.block.id}`]);
-		return items;
-	});
 </script>
 
 <MultiCard>
-	<Card class="text-muted gap-0 bg-transparent px-2 py-0 sm:px-5">
-		<div class="flex items-center gap-2 py-2 text-white">
-			<ArrowRightLeft class="size-4" />
-			<h3 class="text-xl font-semibold">{totalTransactionCount} Transations</h3>
-		</div>
+	{#if data.block.transactions}
+		{@const transactions = data.block.transactions}
+		<Stack id="transactions">
+			<h2 class="h3 flex items-center gap-2">
+				<ArrowLeftRight class="size-5" />
+				{transactions.length}
+				{transactions.length > 1 ? 'Transactions' : 'Transaction'}
+			</h2>
 
-		<div class="grid grid-cols-[1.5fr,1fr,1fr,1fr,0fr] py-3 sm:grid-cols-[1.5fr,1fr,1fr,1fr,0.5fr]">
-			<div>Tx ID</div>
-			<div>Actions</div>
-			<div>CPU</div>
-			<div>NET</div>
-			<div></div>
-		</div>
-
-		<div>
-			{#if totalTransactionCount}
-				{#each data.block.transactions as transaction}
-					{#if transaction}
-						<a
-							href="/{data.network}/transaction/{String(transaction.trx.id)}"
-							class="table-row-border table-row-background group grid grid-cols-[1.5fr,1fr,1fr,1fr,0fr] py-3 sm:grid-cols-[1.5fr,1fr,1fr,1fr,0.5fr]"
-						>
-							<div>
-								<span class="text-skyBlue-500 hover:text-skyBlue-400"
-									>{truncateCenter(String(transaction.trx.id))}</span
-								>
-							</div>
-							<div>
-								{transaction.trx.transaction.actions.length}
-							</div>
-							<div>{transaction.cpu_usage_us} μs</div>
-							<div>{transaction.net_usage_words * 8} Bytes</div>
-							<div class="flex items-center justify-center text-white">
-								<div class="hidden sm:block">
-									<ChevronRight class="size-6 group-hover:stroke-skyBlue-400" />
-								</div>
-							</div>
-						</a>
-					{/if}
-				{/each}
-			{:else}
-				<div
-					class="table-row-border table-row-background group grid grid-cols-[1.5fr,1fr,1fr,1fr,0fr] py-3 sm:grid-cols-[1.5fr,1fr,1fr,1fr,0.5fr]"
-				>
-					<div>-</div>
-					<div>-</div>
-					<div>-</div>
-					<div>-</div>
-					<div></div>
-				</div>
-			{/if}
-		</div>
-	</Card>
-
-	<Card class="gap-0 bg-transparent px-2 py-0 sm:px-5">
-		<div class="py-2">
-			<h3 class="text-xl font-semibold">{data.title} details</h3>
-		</div>
-		<table class="table-styles">
-			<tbody>
-				<tr>
-					<td width="42%" class="text-muted align-top">Producter Name: </td>
-					<td width="58%" class="break-all align-top">
-						<a
-							class="text-skyBlue-500 hover:text-skyBlue-400"
-							href="/{data.network}/account/{data.block.producer}">{data.block.producer}</a
-						></td
-					>
-				</tr>
-				{#each deails as detail}
+			<table class="table-styles">
+				<thead>
 					<tr>
-						<td width="42%" class="text-muted align-top">{detail[0]}: </td>
-						<td width="58%" class="text-wrap break-all align-top">{detail[1]}</td>
+						<th>Transaction</th>
+						<th class="text-right">Actions</th>
+						<th class="text-right">CPU</th>
+						<th class="text-right">NET</th>
 					</tr>
-				{/each}
-			</tbody>
-		</table>
-		<Cluster class="mt-8">
-			<Button href="/{data.network}/block/{Number(data.height) - 1}" variant="secondary"
-				>← Previous Block</Button
-			>
-			<Button href="/{data.network}/block/{Number(data.height) + 1}" variant="secondary"
-				>Next Block →</Button
-			>
-		</Cluster>
-	</Card>
-</MultiCard>
-
-
-<Stack class="@container">
-	<!-- <Pillgroup /> -->
-	<MultiCard>
-		{#if data.block.transactions}
-			{@const transactions = data.block.transactions}
-			<Stack id="transactions">
-				<h2 class="h3 flex items-center gap-2">
-					<ArrowLeftRight class="size-5" />
-					{transactions.length}
-					{transactions.length > 1 ? 'Transactions' : 'Transaction'}
-				</h2>
-				<table class="table-styles">
-					<thead>
-						<tr>
-							<th>Transaction</th>
-							<th>Actions</th>
-							<th>CPU</th>
-							<th>NET</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each transactions as transaction}
+				</thead>
+				<tbody>
+					{#each transactions as transaction}
+						{#if transaction}
 							<tr>
-								<td><Transaction id={transaction.trx.id} /></td>
-								<td>{transaction.trx.transaction?.actions.length}</td>
-								<td>{transaction.cpu_usage_us}</td>
-								<td>{transaction.net_usage_words}</td>
+								<td><TransactionText id={transaction.trx.id} /></td>
+								<td class="text-right">{transaction.trx.transaction?.actions.length}</td>
+								<td class="text-right">{transaction.cpu_usage_us}</td>
+								<td class="text-right">{transaction.net_usage_words}</td>
 							</tr>
-						{/each}
-					</tbody>
-				</table>
-			</Stack>
-		{/if}
-
-		<Stack id="details">
-			<h2 class="h3 flex items-center gap-2">Block Details</h2>
-			<Descriptionlist items={details} />
-			<Switcher>
-				{#if data.height > 1}
-					<Button variant="secondary" href="/{data.network}/block/{Number(data.height) - 1}">
-						{m.block_height_numbered({ height: Number(data.height) - 1 })}
-					</Button>
-				{/if}
-				<Button variant="secondary" href="/{data.network}/block/{Number(data.height) + 1}">
-					{m.block_height_numbered({ height: Number(data.height) + 1 })}
-				</Button>
-			</Switcher>
+						{/if}
+					{/each}
+				</tbody>
+			</table>
 		</Stack>
+	{/if}
 
-		<Code>
-			{JSON.stringify(data.block, null, 2)}
-		</Code>
-	</MultiCard>
-</Stack>
+	<Stack class="gap-4" id="details">
+		<h2 class="h3">Block Details</h2>
+
+		<DL>
+			<DLRow title={'Block Number'}>
+				{data.details.blockNumber}
+			</DLRow>
+			<DLRow title={'Producer Name'}>
+				<AccountText name={data.details.blockProducer} />
+			</DLRow>
+			<DLRow title={'Total CPU'}>
+				{data.details.totalCpu} μs
+			</DLRow>
+			<DLRow title={'Total NET'}>
+				{data.details.totalNet * 8} Bytes
+			</DLRow>
+			<DLRow title={'Total Actions'}>
+				{data.details.totalActions}
+			</DLRow>
+			<DLRow title={'Block ID'}>
+				{data.details.blockId}
+			</DLRow>
+		</DL>
+
+		<Switcher>
+			{#if data.height > 1}
+				<Button href="/{data.network}/block/{Number(data.height) - 1}" variant="secondary">
+					← Previous Block
+				</Button>
+			{/if}
+			<Button href="/{data.network}/block/{Number(data.height) + 1}" variant="secondary">
+				Next Block →
+			</Button>
+		</Switcher>
+	</Stack>
+</MultiCard>

--- a/src/routes/[network]/(explorer)/block/[number]/+page.svelte
+++ b/src/routes/[network]/(explorer)/block/[number]/+page.svelte
@@ -5,9 +5,32 @@
 	import Button from '$lib/components/button/button.svelte';
 	import { ArrowLeftRight, ArrowRight, ArrowLeft } from 'lucide-svelte';
 	import { DL, DLRow } from '$lib/components/descriptionlist/index.js';
+	import { goto } from '$lib/utils';
 
 	let { data } = $props();
+
+	const previousBlockLink = $derived(`/${data.network}/block/${Number(data.height) - 1}`);
+	const nextBlockLink = $derived(`/${data.network}/block/${Number(data.height) + 1}`);
+
+	const handleKeydown = (e: KeyboardEvent) => {
+		// Don't do anything if search is open
+		if (
+			document.activeElement?.tagName === 'INPUT' ||
+			document.activeElement?.tagName === 'TEXTAREA' ||
+			document.activeElement?.getAttribute('contenteditable') === 'true'
+		) {
+			return;
+		}
+
+		if (e.key === 'ArrowRight') {
+			goto(nextBlockLink);
+		} else if (e.key === 'ArrowLeft') {
+			goto(previousBlockLink);
+		}
+	};
 </script>
+
+<svelte:window on:keydown={handleKeydown} />
 
 <MultiCard>
 	{#if data.block.transactions}
@@ -76,13 +99,13 @@
 
 		<Switcher>
 			{#if data.height > 1}
-				<Button href="/{data.network}/block/{Number(data.height) - 1}" variant="secondary">
+				<Button href={previousBlockLink} variant="secondary">
 					<span class="inline-flex items-center gap-1">
 						<ArrowLeft class="size-4" /> Previous Block
 					</span>
 				</Button>
 			{/if}
-			<Button href="/{data.network}/block/{Number(data.height) + 1}" variant="secondary">
+			<Button href={nextBlockLink} variant="secondary">
 				<span class="inline-flex items-center gap-1">
 					Next Block <ArrowRight class="size-4" />
 				</span>

--- a/src/routes/[network]/(explorer)/block/[number]/+page.svelte
+++ b/src/routes/[network]/(explorer)/block/[number]/+page.svelte
@@ -24,18 +24,20 @@
 					<tr>
 						<th>Transaction</th>
 						<th class="text-right">Actions</th>
-						<th class="text-right">CPU</th>
-						<th class="text-right">NET</th>
+						<th class="text-right">CPU (μs)</th>
+						<th class="text-right">NET (Bytes)</th>
 					</tr>
 				</thead>
 				<tbody>
 					{#each transactions as transaction}
 						{#if transaction}
+							{@const txID =
+								typeof transaction.trx === 'string' ? transaction.trx : transaction.trx.id}
 							<tr>
-								<td><TransactionText id={transaction.trx.id} /></td>
-								<td class="text-right">{transaction.trx.transaction?.actions.length}</td>
+								<td><TransactionText id={txID} /></td>
+								<td class="text-right">{transaction.trx.transaction?.actions.length || 0}</td>
 								<td class="text-right">{transaction.cpu_usage_us}</td>
-								<td class="text-right">{transaction.net_usage_words}</td>
+								<td class="text-right">{Number(transaction.net_usage_words) * 8}</td>
 							</tr>
 						{/if}
 					{/each}

--- a/src/routes/[network]/(explorer)/block/[number]/+page.svelte
+++ b/src/routes/[network]/(explorer)/block/[number]/+page.svelte
@@ -16,33 +16,37 @@
 			<h2 class="h3 flex items-center gap-2">
 				<ArrowLeftRight class="size-5" />
 				{transactions.length}
-				{transactions.length > 1 ? 'Transactions' : 'Transaction'}
+				{transactions.length === 1 ? 'Transaction' : 'Transactions'}
 			</h2>
 
-			<table class="table-styles">
-				<thead>
-					<tr>
-						<th>Transaction</th>
-						<th class="text-right">Actions</th>
-						<th class="text-right">CPU (μs)</th>
-						<th class="text-right">NET (Bytes)</th>
-					</tr>
-				</thead>
-				<tbody>
-					{#each transactions as transaction}
-						{#if transaction}
-							{@const txID =
-								typeof transaction.trx === 'string' ? transaction.trx : transaction.trx.id}
-							<tr>
-								<td><TransactionText id={txID} /></td>
-								<td class="text-right">{transaction.trx.transaction?.actions.length || 0}</td>
-								<td class="text-right">{transaction.cpu_usage_us}</td>
-								<td class="text-right">{Number(transaction.net_usage_words) * 8}</td>
-							</tr>
-						{/if}
-					{/each}
-				</tbody>
-			</table>
+			{#if transactions.length}
+				<table class="table-styles">
+					<thead>
+						<tr>
+							<th>Transaction</th>
+							<th class="text-right">Actions</th>
+							<th class="text-right">CPU (μs)</th>
+							<th class="text-right">NET (Bytes)</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each transactions as transaction}
+							{#if transaction}
+								{@const txID =
+									typeof transaction.trx === 'string' ? transaction.trx : transaction.trx.id}
+								<tr>
+									<td><TransactionText id={txID} /></td>
+									<td class="text-right">{transaction.trx.transaction?.actions.length || 0}</td>
+									<td class="text-right">{transaction.cpu_usage_us}</td>
+									<td class="text-right">{Number(transaction.net_usage_words) * 8}</td>
+								</tr>
+							{/if}
+						{/each}
+					</tbody>
+				</table>
+			{:else}
+				<p>No transactions</p>
+			{/if}
 		</Stack>
 	{/if}
 


### PR DESCRIPTION
- changed markup to use common components
- updated description list component to receive children
- combined and moved data processing to `layout.ts` 

I took some design liberties as follows:
- used a description list pattern instead of a table pattern for the block details. Reason: this is key-value data, not tabular data, and we have this pattern elsewhere so I'm changing it for consistency.
- right aligned numerical data
- Use `TransactionText` and `AccountText` components where applicable