### PR TITLE
Refactor pill nav

### DIFF
--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -9,6 +9,7 @@
 		href?: string;
 		variant?: 'primary' | 'secondary' | 'pill' | 'outline';
 		disabled?: boolean;
+		active?: boolean;
 		blank?: boolean;
 		class?: string;
 		children: Snippet;
@@ -17,15 +18,16 @@
 	}
 
 	let {
-		class: className = '',
 		meltAction,
 		onclick,
 		variant = 'primary',
+		active,
 		disabled = false,
 		...props
 	}: ButtonProps = $props();
 
-	const ariaRole = props.href ? 'link' : 'button';
+	const ariaRole = props.href ? undefined : 'button'; // undefined because anchor tag with role=link gives a warning
+	const ariaCurrent = props['aria-current'] || active === false ? undefined : true; // removes aria-current if active===false
 	const tag = props.href ? 'a' : 'button';
 
 	// Only use melt builder element if passed as a prop
@@ -45,17 +47,18 @@
 	this={tag}
 	use:melt={$meltElement}
 	data-variant={variant}
-	class={className}
+	class={props.class || ''}
 	role={ariaRole}
+	aria-current={ariaCurrent}
 	{disabled}
 	{onclick}
 	{...props}
 	{...linkProps}
 >
-	<span class="button-text">{@render props.children()}</span>
+	<span>{@render props.children()}</span>
 </svelte:element>
 
-<style>
+<style lang="postcss">
 	[data-variant='primary'] {
 		@apply relative inline-flex h-12 grow items-center justify-center text-nowrap rounded-lg bg-skyBlue-700 px-8 text-center text-base font-medium text-skyBlue-50 transition-all focus:outline-transparent focus-visible:outline focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-solar-500 hover:active:bg-skyBlue-800 disabled:cursor-not-allowed disabled:bg-mineShaft-900 disabled:text-white/60 disabled:opacity-30 disabled:hover:bg-mineShaft-900 [@media(any-hover:hover)]:hover:bg-skyBlue-600;
 	}
@@ -65,10 +68,10 @@
 	}
 
 	[data-variant='pill'] {
-		@apply relative inline-flex h-10 items-center justify-center text-nowrap rounded-full border-2 border-transparent px-5 text-center text-base font-medium leading-4 transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-solar-500 hover:active:bg-mineShaft-950 aria-[current=page]:border-mineShaft-200/30 [@media(any-hover:hover)]:hover:bg-mineShaft-900 [@media(any-hover:hover)]:hover:text-mineShaft-100;
+		@apply relative inline-flex h-10 items-center justify-center text-nowrap rounded-full border-2 border-transparent px-5 text-center text-base font-medium leading-4 transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-solar-500 hover:active:bg-mineShaft-950 aria-[current]:border-mineShaft-200/30 [@media(any-hover:hover)]:hover:bg-mineShaft-900 [@media(any-hover:hover)]:hover:text-mineShaft-100;
 	}
 
-	.button-text {
+	span {
 		@apply pointer-events-none relative text-inherit;
 	}
 </style>

--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -9,7 +9,6 @@
 		href?: string;
 		variant?: 'primary' | 'secondary' | 'pill' | 'outline';
 		disabled?: boolean;
-		active?: boolean;
 		blank?: boolean;
 		class?: string;
 		children: Snippet;
@@ -22,7 +21,6 @@
 		meltAction,
 		onclick,
 		variant = 'primary',
-		active = false,
 		disabled = false,
 		...props
 	}: ButtonProps = $props();
@@ -46,7 +44,6 @@
 <svelte:element
 	this={tag}
 	use:melt={$meltElement}
-	data-active={active}
 	data-variant={variant}
 	class={className}
 	role={ariaRole}
@@ -68,7 +65,7 @@
 	}
 
 	[data-variant='pill'] {
-		@apply relative inline-flex h-10 items-center justify-center text-nowrap rounded-full border-2 border-transparent px-5 text-center text-base font-medium leading-4 transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-solar-500 hover:active:bg-mineShaft-950 data-[active=true]:border-mineShaft-200/30 [@media(any-hover:hover)]:hover:bg-mineShaft-900 [@media(any-hover:hover)]:hover:text-mineShaft-100;
+		@apply relative inline-flex h-10 items-center justify-center text-nowrap rounded-full border-2 border-transparent px-5 text-center text-base font-medium leading-4 transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-solar-500 hover:active:bg-mineShaft-950 aria-[current=page]:border-mineShaft-200/30 [@media(any-hover:hover)]:hover:bg-mineShaft-900 [@media(any-hover:hover)]:hover:text-mineShaft-100;
 	}
 
 	.button-text {

--- a/src/lib/components/navigation/pillgroup.svelte
+++ b/src/lib/components/navigation/pillgroup.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/components/button/button.svelte';
+	import { page } from '$app/stores';
 	import { cn } from '$lib/utils';
 	import type { ComponentProps } from 'svelte';
 
@@ -11,13 +12,22 @@
 		options: Option[];
 		class?: string;
 	}
+
 	const { class: className, ...props }: Props = $props();
+
+	let pathWithoutLanguageTag = $derived($page.url.pathname.slice(3));
+
+	const isCurrent = (option: Option) => pathWithoutLanguageTag === option.href;
 </script>
 
 <menu aria-label="page functions" class={cn('flex flex-wrap gap-3 ', className)}>
 	{#each props.options as option}
 		<li>
-			<Button variant="pill" active={option.active} href={option.href}>
+			<Button
+				variant="pill"
+				aria-current={isCurrent(option) ? 'page' : undefined}
+				href={option.href}
+			>
 				{option.text}
 			</Button>
 		</li>

--- a/src/routes/[network]/(account)/(send)/+layout.svelte
+++ b/src/routes/[network]/(account)/(send)/+layout.svelte
@@ -1,25 +1,15 @@
 <script lang="ts">
 	import PillGroup from '$lib/components/navigation/pillgroup.svelte';
-	import { page } from '$app/stores';
 
 	const { children, data } = $props();
 
-	const tabOptions = $derived.by(() => {
+	const options = $derived.by(() => {
 		const network = String(data.network);
 		return [
 			{ href: `/${network}/send`, text: 'Send' },
 			{ href: `/${network}/receive`, text: 'Receive' }
 		];
 	});
-
-	let currentTab = $derived($page.url.pathname.split('/')[3]);
-
-	let options = $derived(
-		tabOptions.map((option) => ({
-			...option,
-			active: option.href.split('/')[2] === currentTab
-		}))
-	);
 </script>
 
 <PillGroup {options} class="mb-6 hidden" />

--- a/src/routes/[network]/(dev)/debug/components/sections/navigation.svelte
+++ b/src/routes/[network]/(dev)/debug/components/sections/navigation.svelte
@@ -26,7 +26,7 @@
 		<h3 class="h3">Page Actions</h3>
 		<PillGroup
 			options={[
-				{ href: '#', text: 'Overview', active: true },
+				{ href: '#', text: 'Overview' },
 				{ href: '#', text: 'Stake' },
 				{ href: '#', text: 'Unstake' },
 				{ href: '#', text: 'Withdraw' }

--- a/src/routes/[network]/(explorer)/account/[name]/+layout.svelte
+++ b/src/routes/[network]/(explorer)/account/[name]/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
-	import { page } from '$app/stores';
 	import { Stack } from '$lib/components/layout';
 	import PillGroup from '$lib/components/navigation/pillgroup.svelte';
 	import type { UnicoveContext } from '$lib/state/client.svelte.js';
@@ -8,7 +7,7 @@
 	const context = getContext<UnicoveContext>('state');
 	const { children, data } = $props();
 
-	const tabOptions = $derived.by(() => {
+	const options = $derived.by(() => {
 		const account = String(data.account.name);
 		const network = String(data.account.network);
 		let items = [
@@ -27,16 +26,6 @@
 
 		return items;
 	});
-
-	let currentTab = $derived($page.url.pathname.split('/').slice(2)[3]);
-
-	// Derive the active state of each destination
-	let options = $derived(
-		tabOptions.map((option) => ({
-			...option,
-			active: option.href.split('/').slice(2)[2] === currentTab
-		}))
-	);
 </script>
 
 <Stack class="gap-6 @container">

--- a/src/routes/[network]/(explorer)/block/[number]/+layout.svelte
+++ b/src/routes/[network]/(explorer)/block/[number]/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { page } from '$app/stores';
 	import { Stack } from '$lib/components/layout/index.js';
 	import PillGroup from '$lib/components/navigation/pillgroup.svelte';
 	import type { UnicoveContext } from '$lib/state/client.svelte.js';
@@ -9,23 +8,13 @@
 
 	const { settings } = getContext<UnicoveContext>('state');
 
-	const tabOptions = $derived.by(() => {
+	const options = $derived.by(() => {
 		let urlBase = `/${data.network}/block/${data.number}`;
 		return [
 			{ href: urlBase, text: 'Summary' },
 			{ href: `${urlBase}/data`, text: 'Data' }
 		];
 	});
-
-	let currentTab = $derived($page.url.pathname.split('/').slice(2)[3]);
-
-	// Derive the active state of each destination
-	let options = $derived(
-		tabOptions.map((option) => ({
-			...option,
-			active: option.href.split('/').slice(2)[2] === currentTab
-		}))
-	);
 </script>
 
 <Stack class="@container">

--- a/src/routes/[network]/(explorer)/contract/[contract]/+layout.svelte
+++ b/src/routes/[network]/(explorer)/contract/[contract]/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { page } from '$app/stores';
 	import PillGroup from '$lib/components/navigation/pillgroup.svelte';
 	import { Contract } from '@wharfkit/contract';
 	import { setContext } from 'svelte';
@@ -15,7 +14,7 @@
 		})
 	);
 
-	const tabOptions = $derived.by(() => {
+	const options = $derived.by(() => {
 		const account = String(data.contract);
 		const network = String(data.network);
 		return [
@@ -35,16 +34,6 @@
 			{ href: `/${network}/contract/${account}/abi`, text: 'ABI' }
 		];
 	});
-
-	let currentTab = $derived($page.url.pathname.split('/').slice(2)[3]);
-
-	// Derive the active state of each destination
-	let options = $derived(
-		tabOptions.map((option) => ({
-			...option,
-			active: option.href.split('/').slice(2)[2] === currentTab
-		}))
-	);
 </script>
 
 <!-- <Stack class="gap-2"> -->

--- a/src/routes/[network]/(explorer)/transaction/[id]/[[seq]]/+layout.svelte
+++ b/src/routes/[network]/(explorer)/transaction/[id]/[[seq]]/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { page } from '$app/stores';
 	import { Stack } from '$lib/components/layout/index.js';
 	import PillGroup from '$lib/components/navigation/pillgroup.svelte';
 	import { type UnicoveContext } from '$lib/state/client.svelte.js';
@@ -9,7 +8,7 @@
 
 	const { settings } = getContext<UnicoveContext>('state');
 
-	const tabOptions = $derived.by(() => {
+	const options = $derived.by(() => {
 		let urlBase = `/${data.network}/transaction/${data.id}`;
 		if (data.seq) {
 			urlBase += `/${data.seq}`;
@@ -20,16 +19,6 @@
 			{ href: `${urlBase}/data`, text: 'Data' }
 		];
 	});
-
-	let currentTab = $derived($page.url.pathname.split('/').slice(2)[3]);
-
-	// Derive the active state of each destination
-	let options = $derived(
-		tabOptions.map((option) => ({
-			...option,
-			active: option.href.split('/').slice(2)[2] === currentTab
-		}))
-	);
 </script>
 
 <Stack class="@container">


### PR DESCRIPTION
Centralizing our active page check into the navigation component means we don't have to check in every layout.

Use `aria-current=page` instead of a custom `active` class for more semantic html and better a11y