### PR TITLE
refactor(button): allow overriding button classes

### DIFF
--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { cn } from '$lib/utils';
 	import { emptyMeltElement, melt, type AnyMeltElement } from '@melt-ui/svelte';
 	import type { Snippet } from 'svelte';
 	import type { HTMLButtonAttributes, HTMLLinkAttributes } from 'svelte/elements';
@@ -7,7 +8,7 @@
 
 	interface ButtonProps extends HTMLAttributes {
 		href?: string;
-		variant?: 'primary' | 'secondary' | 'pill' | 'outline';
+		variant?: 'primary' | 'secondary' | 'pill';
 		disabled?: boolean;
 		active?: boolean;
 		blank?: boolean;
@@ -22,6 +23,7 @@
 		onclick,
 		variant = 'primary',
 		active,
+		class: className,
 		disabled = false,
 		...props
 	}: ButtonProps = $props();
@@ -41,13 +43,27 @@
 				}
 			: {}
 	);
+
+	const primaryStyles =
+		'relative inline-flex h-12 grow items-center justify-center text-nowrap rounded-lg bg-skyBlue-700 px-8 text-center text-base font-medium text-skyBlue-50 transition-all focus:outline-transparent focus-visible:outline focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-solar-500 hover:active:bg-skyBlue-800 disabled:cursor-not-allowed disabled:bg-mineShaft-900 disabled:text-white/60 disabled:opacity-30 disabled:hover:bg-mineShaft-900 [@media(any-hover:hover)]:hover:bg-skyBlue-600';
+
+	const secondaryStyles =
+		'relative flex h-12 grow items-center justify-center text-nowrap rounded-lg px-8 text-center text-base font-medium text-skyBlue-400 ring-2 ring-inset ring-mineShaft-600 transition-all hover:ring-transparent focus-visible:outline-none focus-visible:ring-solar-500 hover:active:bg-mineShaft-950 hover:active:ring-mineShaft-900 disabled:cursor-not-allowed disabled:text-mineShaft-400 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:ring-mineShaft-600 disabled:active:ring-mineShaft-600 [@media(any-hover:hover)]:hover:bg-mineShaft-900';
+
+	const pillStyles =
+		'relative inline-flex h-10 items-center justify-center text-nowrap rounded-full border-2 border-transparent px-5 text-center text-base font-medium leading-4 transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-solar-500 hover:active:bg-mineShaft-950 aria-[current]:border-mineShaft-200/30 [@media(any-hover:hover)]:hover:bg-mineShaft-900 [@media(any-hover:hover)]:hover:text-mineShaft-100';
+
+	let styles = {
+		primary: primaryStyles,
+		secondary: secondaryStyles,
+		pill: pillStyles
+	};
 </script>
 
 <svelte:element
 	this={tag}
 	use:melt={$meltElement}
-	data-variant={variant}
-	class={props.class || ''}
+	class={cn(styles[variant], className)}
 	role={ariaRole}
 	aria-current={ariaCurrent}
 	{disabled}
@@ -55,23 +71,5 @@
 	{...props}
 	{...linkProps}
 >
-	<span>{@render props.children()}</span>
+	<span class="pointer-events-none relative text-inherit">{@render props.children()}</span>
 </svelte:element>
-
-<style lang="postcss">
-	[data-variant='primary'] {
-		@apply relative inline-flex h-12 grow items-center justify-center text-nowrap rounded-lg bg-skyBlue-700 px-8 text-center text-base font-medium text-skyBlue-50 transition-all focus:outline-transparent focus-visible:outline focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-solar-500 hover:active:bg-skyBlue-800 disabled:cursor-not-allowed disabled:bg-mineShaft-900 disabled:text-white/60 disabled:opacity-30 disabled:hover:bg-mineShaft-900 [@media(any-hover:hover)]:hover:bg-skyBlue-600;
-	}
-
-	[data-variant='secondary'] {
-		@apply relative flex h-12 grow items-center justify-center text-nowrap rounded-lg px-8 text-center text-base font-medium text-skyBlue-400 ring-2 ring-inset ring-mineShaft-600 transition-all hover:ring-transparent focus-visible:outline-none focus-visible:ring-solar-500 hover:active:bg-mineShaft-950 hover:active:ring-mineShaft-900 disabled:cursor-not-allowed disabled:text-mineShaft-400 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:ring-mineShaft-600 disabled:active:ring-mineShaft-600 [@media(any-hover:hover)]:hover:bg-mineShaft-900;
-	}
-
-	[data-variant='pill'] {
-		@apply relative inline-flex h-10 items-center justify-center text-nowrap rounded-full border-2 border-transparent px-5 text-center text-base font-medium leading-4 transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-solar-500 hover:active:bg-mineShaft-950 aria-[current]:border-mineShaft-200/30 [@media(any-hover:hover)]:hover:bg-mineShaft-900 [@media(any-hover:hover)]:hover:text-mineShaft-100;
-	}
-
-	span {
-		@apply pointer-events-none relative text-inherit;
-	}
-</style>


### PR DESCRIPTION
Refactor button component styles for two reasons

1. Moves everything to tailwind classes removing the need for an additional stylesheet
2. Enables overriding default button classes in special cases