### PR TITLE
fix: horizontal shift on long pages

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -7,6 +7,7 @@
 		@apply h-full bg-shark-950 text-white;
 		color-scheme: dark;
 		touch-action: manipulation;
+		scrollbar-gutter: stable;
 	}
 
 	body {


### PR DESCRIPTION
Fixes a style issue where the page would shift horizontally ~15px when navigating between a page with a scrollbar and a page without a scrollbar (e.g. from Home to My Account). This was most noticable in the left side navigation menu. 

With this change, the page maintains its horiztonal position regardless of a scrollbar. 