### PR TITLE
opengraph images

### DIFF
--- a/src/lib/utils/opengraph.ts
+++ b/src/lib/utils/opengraph.ts
@@ -14,7 +14,6 @@ export function ogImage(url: URL) {
 /**
  * A map of valid route names to their captions. Prevents users from generating invalid opengraph images.
  */
-
 export function getCaption(route: string, network: NetworkState) {
 	switch (route) {
 		case 'send':

--- a/src/lib/utils/opengraph.ts
+++ b/src/lib/utils/opengraph.ts
@@ -1,26 +1,9 @@
-import * as m from '$lib/paraglide/messages';
-import type { NetworkState } from '$lib/state/network.svelte';
-
 /**
- * Creates the api url to generate an opengraph image for the specified route.
- * Defaults to the generic caption.
+ * Creates the canonical url for the opengraph image of the specified route.
+ * Accessing this url generates an image based on the predefined options found at the api endpoint.
  */
-export function ogImage(url: URL) {
+export function ogImageUrl(url: URL) {
 	const [lang, network, ...rest] = url.pathname.split('/').filter(Boolean);
 	const filename = rest.length ? rest.join('/') : 'default';
 	return `${url.origin}/${lang}/${network}/api/og/${filename}.png`;
-}
-
-/**
- * A map of valid route names to their captions. Prevents users from generating invalid opengraph images.
- */
-export function getCaption(route: string, network: NetworkState) {
-	switch (route) {
-		case 'send':
-			return m.og_send_caption();
-		default:
-			return m.og_default_caption({
-				network: network.chain.name
-			});
-	}
 }

--- a/src/routes/[network]/(account)/(send)/+layout.ts
+++ b/src/routes/[network]/(account)/(send)/+layout.ts
@@ -1,6 +1,6 @@
 import type { LayoutLoad } from './$types';
 import * as m from '$lib/paraglide/messages';
-import { ogImage } from '$lib/utils/opengraph';
+import { ogImageUrl } from '$lib/utils/opengraph';
 
 export const load: LayoutLoad = async ({ url, parent }) => {
 	const { network } = await parent();
@@ -12,7 +12,7 @@ export const load: LayoutLoad = async ({ url, parent }) => {
 			description: m.send_page_description({
 				network: network.chain.name
 			}),
-			open_graph_image: ogImage(url)
+			open_graph_image: ogImageUrl(url)
 		}
 	};
 };

--- a/src/routes/[network]/(dev)/debug/+page.svelte
+++ b/src/routes/[network]/(dev)/debug/+page.svelte
@@ -17,6 +17,9 @@
 		<a href="debug/input/name">Input/Name</a>
 	</li>
 	<li>
+		<a href="debug/opengraph">Opengraph Images</a>
+	</li>
+	<li>
 		<a href="debug/state">State</a>
 	</li>
 	<li>

--- a/src/routes/[network]/(dev)/debug/+page.svelte
+++ b/src/routes/[network]/(dev)/debug/+page.svelte
@@ -1,0 +1,34 @@
+<script>
+	let props = $props();
+</script>
+
+<h1 class="h2">Debug</h1>
+<ul class="mt-4 list-disc space-y-2">
+	<li>
+		<a href="debug/account">Account</a>
+	</li>
+	<li>
+		<a href="debug/components">Components</a>
+	</li>
+	<li>
+		<a href="debug/input/asset">Input/Asset</a>
+	</li>
+	<li>
+		<a href="debug/input/name">Input/Name</a>
+	</li>
+	<li>
+		<a href="debug/state">State</a>
+	</li>
+	<li>
+		<a href="debug/state/account">State/Account</a>
+	</li>
+	<li>
+		<a href="debug/state/config">State/Config</a>
+	</li>
+	<li>
+		<a href="debug/state/network">State/Network</a>
+	</li>
+	<li>
+		<a href="debug/state/wharf">State/Wharf</a>
+	</li>
+</ul>

--- a/src/routes/[network]/(dev)/debug/opengraph/+page.svelte
+++ b/src/routes/[network]/(dev)/debug/opengraph/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { ogImage } from '$lib/utils/opengraph';
+	import { ogImageUrl } from '$lib/utils/opengraph';
 
 	let { data } = $props();
 	const { url, baseMetaTags } = data;
@@ -13,7 +13,7 @@
 <section class="space-y-6">
 	<h1 class="h2">Opengraph Images</h1>
 	<img src={og_default} alt="" />
-	<img src={ogImage(test1)} alt="" />
-	<img src={ogImage(test2)} alt="" />
-	<img src={ogImage(test3)} alt="" />
+	<img src={ogImageUrl(test1)} alt="" />
+	<img src={ogImageUrl(test2)} alt="" />
+	<img src={ogImageUrl(test3)} alt="" />
 </section>

--- a/src/routes/[network]/(dev)/debug/opengraph/+page.svelte
+++ b/src/routes/[network]/(dev)/debug/opengraph/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { ogImage } from '$lib/utils/opengraph';
+
+	let { data } = $props();
+	const { url, baseMetaTags } = data;
+
+	const og_default = baseMetaTags.open_graph_image;
+	const test1 = new URL(url.origin + '/en/eos/send');
+	const test2 = new URL(url.origin + '/zh/eos/send');
+	const test3 = new URL(url.origin + '/ko/eos/send');
+</script>
+
+<section class="space-y-6">
+	<h1 class="h2">Opengraph Images</h1>
+	<img src={og_default} alt="" />
+	<img src={ogImage(test1)} alt="" />
+	<img src={ogImage(test2)} alt="" />
+	<img src={ogImage(test3)} alt="" />
+</section>

--- a/src/routes/[network]/(dev)/debug/opengraph/+page.ts
+++ b/src/routes/[network]/(dev)/debug/opengraph/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = ({ url }) => {
+	return {
+		url
+	};
+};

--- a/src/routes/[network]/+layout.server.ts
+++ b/src/routes/[network]/+layout.server.ts
@@ -1,7 +1,7 @@
 import { type SeoConfig } from 'svead';
 import { i18n } from '$lib/i18n';
 import * as m from '$lib/paraglide/messages';
-import { ogImage } from '$lib/utils/opengraph';
+import { ogImageUrl } from '$lib/utils/opengraph';
 import type { LayoutServerLoad } from './$types';
 import type { NetworkState } from '$lib/state/network.svelte';
 
@@ -17,7 +17,7 @@ function generateMetadata(url: URL, network: NetworkState): SeoConfig {
 		description: m.og_default_description({
 			network: network.chain.name
 		}),
-		open_graph_image: ogImage(url)
+		open_graph_image: ogImageUrl(url)
 	};
 }
 

--- a/src/routes/[network]/api/og/[...route].png/+server.ts
+++ b/src/routes/[network]/api/og/[...route].png/+server.ts
@@ -12,12 +12,17 @@ export const GET: RequestHandler = async ({ locals, url, fetch, params }) => {
 	let response: Response;
 
 	const API_OPENGRAPH_GENERATOR = env.API_OPENGRAPH_GENERATOR;
+	const API_OPENGRAPH_TOKEN = env.API_OPENGRAPH_TOKEN;
 
 	if (API_OPENGRAPH_GENERATOR) {
 		const uri = new URL(API_OPENGRAPH_GENERATOR);
 		uri.searchParams.set('text', text);
 		uri.searchParams.set('lang', lang);
-		response = await fetch(uri.toString());
+		response = await fetch(uri.toString(), {
+			headers: {
+				Authorization: `Bearer ${API_OPENGRAPH_TOKEN}`
+			}
+		});
 	} else {
 		// Uses a local image if no API is provided
 		response = await fetch('/opengraph/default.png');

--- a/src/routes/[network]/api/og/[...route].png/+server.ts
+++ b/src/routes/[network]/api/og/[...route].png/+server.ts
@@ -14,7 +14,9 @@ export const GET: RequestHandler = async ({ locals, url, fetch, params }) => {
 	const API_OPENGRAPH_GENERATOR = env.API_OPENGRAPH_GENERATOR;
 	const API_OPENGRAPH_TOKEN = env.API_OPENGRAPH_TOKEN;
 
-	if (API_OPENGRAPH_GENERATOR) {
+	if (!API_OPENGRAPH_GENERATOR || !API_OPENGRAPH_TOKEN) {
+		response = await fetch('/opengraph/default.png'); // default local image
+	} else {
 		const uri = new URL(API_OPENGRAPH_GENERATOR);
 		uri.searchParams.set('text', text);
 		if (title) uri.searchParams.set('title', title);
@@ -25,9 +27,6 @@ export const GET: RequestHandler = async ({ locals, url, fetch, params }) => {
 				Authorization: `Bearer ${API_OPENGRAPH_TOKEN}`
 			}
 		});
-	} else {
-		// Uses the default local image if no API is provided e.g. dev env
-		response = await fetch('/opengraph/default.png');
 	}
 
 	return new Response(await response.arrayBuffer(), {

--- a/src/routes/[network]/api/og/[...route].png/data.ts
+++ b/src/routes/[network]/api/og/[...route].png/data.ts
@@ -1,0 +1,34 @@
+import * as m from '$lib/paraglide/messages';
+import type { NetworkState } from '$lib/state/network.svelte';
+
+export type OpengraphImageOption = {
+	text: string;
+	title?: string;
+	layout?: number;
+};
+
+/**
+ * A map of valid route names to their opengraph image options.
+ * 1) Prevents users from generating custom opengraph images.
+ * 2) Allows passing more values to the generator api.
+ *
+ * Since the opengraph image needs to be accessible from a static url we need an intermediate step
+ * to include the options required to generate that image (e.g. text, title, layout, etc.) and
+ * the security token in the header of the api request.
+ */
+export function ogImageData(route: string, network: NetworkState): OpengraphImageOption {
+	switch (route) {
+		case 'send':
+			return {
+				text: m.og_send_caption(),
+				title: m.common_send_tokens(),
+				layout: 1
+			};
+		default:
+			return {
+				text: m.og_default_caption({
+					network: network.chain.name
+				})
+			};
+	}
+}


### PR DESCRIPTION
This PR:
- add support for multiple layouts
- include token-based authentication for image generator service
- add test page for opengraph images at `/debug/opengraph`
- add basic index page for the various debug pages

The opengraph image needs to be accessible from a url like `http://unicove.com/en/eos/og_default.png` in the head of the document, but we also need some way of changing the image parameters e.g. title, text, layout, language, etc.

There were two approaches I considered to include all the various options we needed for generation:

1) add them to the image url like `http://unicove.com/en/eos/layout-1/Title%20of%20the%20image/Text%20of%20image/og_default.png` or `http://unicove.com/en/eos/og_default.png?text=Text%20of%20image&layout=1`

Upside to this approach is all configuration could happen at the `+page.ts` load function of the particular route. 

But using params like this would open the api to potential abuse and create massive urls. Even with a token-based authentication between unicove.com and the image-generator service, anyone could just change the query params and unicove would generate a valid image

2) map image routes to their image generator properties

example: `http://unicove.com/en/eos/send` uses the image at `http://unicove.com/en/eos/api/og/send.png`  which uses the predefined options for that route (text, title, layout, language, network, etc.)

The upside is no invalid images can be generated, but the tradeoff is all configuration needs to be done in a centralized place (in this case, the object at the api endpoint)

Note: two new env variables are needed

`API_OPENGRAPH_GENERATOR` is the url of the endpoint for the image generator
`API_OPENGRAPH_TOKEN` is the shared token that matches the endpoint