### PR TITLE
refactor: pageheader actions

### DIFF
--- a/src/lib/components/pageheader.svelte
+++ b/src/lib/components/pageheader.svelte
@@ -27,10 +27,6 @@
 	}
 
 	let logo = $derived(props.network.config.logo || '');
-
-	// let routePath = $derived(page.url.pathname.split('/')[3]);
-	// let contractPath = $derived(`/${props.network}/contract/${props.title}`);
-	// let accountPath = $derived(`/${props.network}/account/${props.title}`);
 </script>
 
 <header class="col-span-full flex min-h-16 items-center gap-4">
@@ -65,17 +61,6 @@
 					<IconButton icon={action.icon} href={action.href} hideBackground />
 				{/each}
 			{/if}
-
-			<!---->
-			<!-- {#if routePath === 'account'} -->
-			<!-- 	{#if props.contract} -->
-			<!-- 		<IconButton icon={Code} href={contractPath} hideBackground /> -->
-			<!-- 	{/if} -->
-			<!-- {/if} -->
-			<!---->
-			<!-- {#if routePath === 'contract'} -->
-			<!-- 	<IconButton icon={User} href={accountPath} hideBackground /> -->
-			<!-- {/if} -->
 		</div>
 
 		{#if props.subtitle}

--- a/src/lib/components/pageheader.svelte
+++ b/src/lib/components/pageheader.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { page } from '$app/state';
 	import IconButton from './button/icon.svelte';
 	import CopyButton from '$lib/components/button/copy.svelte';
 	import { type NetworkState } from '$lib/state/network.svelte';
-	import { Code, User } from 'lucide-svelte';
 	import ChevronLeft from 'lucide-svelte/icons/chevron-left';
+	import type { ComponentProps } from 'svelte';
 
 	interface Props {
 		title: string;
@@ -13,6 +12,8 @@
 		backPath?: string;
 		network: NetworkState;
 		contract?: boolean;
+		copyData?: string;
+		actions?: ComponentProps<typeof IconButton>[];
 	}
 
 	let props: Props = $props();
@@ -27,9 +28,9 @@
 
 	let logo = $derived(props.network.config.logo || '');
 
-	let routePath = $derived(page.url.pathname.split('/')[3]);
-	let contractPath = $derived(`/${props.network}/contract/${props.title}`);
-	let accountPath = $derived(`/${props.network}/account/${props.title}`);
+	// let routePath = $derived(page.url.pathname.split('/')[3]);
+	// let contractPath = $derived(`/${props.network}/contract/${props.title}`);
+	// let accountPath = $derived(`/${props.network}/account/${props.title}`);
 </script>
 
 <header class="col-span-full flex min-h-16 items-center gap-4">
@@ -54,17 +55,27 @@
 	<div class="">
 		<div class="text-primary flex h-fit w-fit items-center">
 			<h1 class="text-on-surface mb-2 text-3xl leading-none font-bold">{props.title}</h1>
-			{#if routePath === 'account'}
-				<CopyButton data={props.title} hideBackground />
-				{#if props.contract}
-					<IconButton icon={Code} href={contractPath} hideBackground />
-				{/if}
+
+			{#if props.copyData}
+				<CopyButton data={props.copyData} hideBackground />
 			{/if}
 
-			{#if routePath === 'contract'}
-				<CopyButton data={props.title} hideBackground />
-				<IconButton icon={User} href={accountPath} hideBackground />
+			{#if props.actions}
+				{#each props.actions as action}
+					<IconButton icon={action.icon} href={action.href} hideBackground />
+				{/each}
 			{/if}
+
+			<!---->
+			<!-- {#if routePath === 'account'} -->
+			<!-- 	{#if props.contract} -->
+			<!-- 		<IconButton icon={Code} href={contractPath} hideBackground /> -->
+			<!-- 	{/if} -->
+			<!-- {/if} -->
+			<!---->
+			<!-- {#if routePath === 'contract'} -->
+			<!-- 	<IconButton icon={User} href={accountPath} hideBackground /> -->
+			<!-- {/if} -->
 		</div>
 
 		{#if props.subtitle}

--- a/src/routes/[network]/(explorer)/+layout.svelte
+++ b/src/routes/[network]/(explorer)/+layout.svelte
@@ -13,6 +13,8 @@
 		subtitle={page.data.subtitle}
 		backPath={page.data.backPath}
 		contract={page.data.account?.contract}
+		actions={page.data?.header?.actions}
+		copyData={page.data?.header?.copyData}
 	/>
 
 	{@render children()}

--- a/src/routes/[network]/(explorer)/account/[name]/+layout.ts
+++ b/src/routes/[network]/(explorer)/account/[name]/+layout.ts
@@ -5,9 +5,10 @@ import * as m from '$lib/paraglide/messages';
 import { getNetworkByName } from '$lib/state/network.svelte';
 import type { LayoutLoad } from './$types';
 import { PUBLIC_CHAIN_SHORT } from '$env/static/public';
+import { Code } from 'lucide-svelte';
 
 export const load: LayoutLoad = async ({ fetch, params }) => {
-	const network = await getNetworkByName(PUBLIC_CHAIN_SHORT, fetch);
+	const network = getNetworkByName(PUBLIC_CHAIN_SHORT, fetch);
 	if (!network.loaded) {
 		await network.refresh();
 	}
@@ -30,6 +31,10 @@ export const load: LayoutLoad = async ({ fetch, params }) => {
 		subtitle: m.account_page_subtitle({
 			network: network.chain.name
 		}),
+		header: {
+			copyData: params.name,
+			actions: [{ icon: Code, href: `/${network}/contract/${params.name}` }]
+		},
 		pageMetaTags: {
 			title: m.account_meta_title({
 				account: String(params.name),

--- a/src/routes/[network]/(explorer)/account/[name]/+layout.ts
+++ b/src/routes/[network]/(explorer)/account/[name]/+layout.ts
@@ -24,6 +24,13 @@ export const load: LayoutLoad = async ({ fetch, params }) => {
 			code: 'NOT_FOUND'
 		});
 	}
+
+	const actions = [];
+
+	if (account.contract) {
+		actions.push({ icon: Code, href: `/${network}/contract/${params.name}` });
+	}
+
 	return {
 		account,
 		name: params.name,
@@ -33,7 +40,7 @@ export const load: LayoutLoad = async ({ fetch, params }) => {
 		}),
 		header: {
 			copyData: params.name,
-			actions: [{ icon: Code, href: `/${network}/contract/${params.name}` }]
+			actions: actions
 		},
 		pageMetaTags: {
 			title: m.account_meta_title({

--- a/src/routes/[network]/(explorer)/block/[number]/+layout.ts
+++ b/src/routes/[network]/(explorer)/block/[number]/+layout.ts
@@ -44,6 +44,9 @@ export const load: LayoutLoad = async ({ fetch, params, parent }) => {
 		number: params.number,
 		title,
 		subtitle: date.toISOString(),
+		header: {
+			copyData: params.number
+		},
 		block,
 		details,
 		network: PUBLIC_CHAIN_SHORT,

--- a/src/routes/[network]/(explorer)/contract/[contract]/+layout.ts
+++ b/src/routes/[network]/(explorer)/contract/[contract]/+layout.ts
@@ -3,6 +3,7 @@ import { error } from '@sveltejs/kit';
 
 import * as m from '$lib/paraglide/messages.js';
 import type { LayoutLoad } from './$types';
+import { User } from 'lucide-svelte';
 
 export const load: LayoutLoad = async ({ fetch, params, parent }) => {
 	const { network } = await parent();
@@ -23,7 +24,10 @@ export const load: LayoutLoad = async ({ fetch, params, parent }) => {
 
 		title: params.contract,
 		subtitle: 'Contract',
-
+		header: {
+			copyData: String(params.contract),
+			actions: [{ icon: User, href: `/${network}/account/${params.contract}` }]
+		},
 		pageMetaTags: {
 			title: m.contract_view_title({
 				contract: String(params.contract),

--- a/src/routes/[network]/(explorer)/key/[publicKey]/+page.ts
+++ b/src/routes/[network]/(explorer)/key/[publicKey]/+page.ts
@@ -21,6 +21,9 @@ export const load: PageLoad = async ({ fetch, params, parent }) => {
 		.then((response) => response.json())
 		.then((json) => json.accounts || []);
 
+	// TODO: The title should follow the rest of the sections of the explorer and be the public key.
+	// The pageheader component should be in charge of visually truncating the text but the full text should
+	// still be in the DOM for a11y and SEO
 	const title = m.key_page_title();
 	const description = m.key_page_description({
 		accounts: accounts.length,
@@ -31,6 +34,9 @@ export const load: PageLoad = async ({ fetch, params, parent }) => {
 	return {
 		title,
 		subtitle,
+		header: {
+			copyData: pubkey
+		},
 		publicKey: pubkey,
 		accounts,
 		network: PUBLIC_CHAIN_SHORT,

--- a/src/routes/[network]/(explorer)/msig/[proposer]/[proposal]/+layout.ts
+++ b/src/routes/[network]/(explorer)/msig/[proposer]/[proposal]/+layout.ts
@@ -39,6 +39,9 @@ export const load: LayoutLoad = async ({ fetch, params, parent }) => {
 			proposer: params.proposer,
 			network: network.chain.name
 		}),
+		header: {
+			copyData: params.proposal
+		},
 		proposal: {
 			approvals: { proposal_name, requested_approvals, provided_approvals, version },
 			proposer: params.proposer,

--- a/src/routes/[network]/(explorer)/transaction/[id]/[[seq]]/+layout.ts
+++ b/src/routes/[network]/(explorer)/transaction/[id]/[[seq]]/+layout.ts
@@ -30,6 +30,9 @@ export const load: LayoutLoad = async ({ fetch, params, parent }) => {
 				timeZone: 'UTC'
 			})
 		}),
+		header: {
+			copyData: params.id
+		},
 		id: params.id,
 		seq: params.seq,
 		pageMetaTags: {


### PR DESCRIPTION
Pageheader actions (e.g. copy, switch between account/contract) are now defined in the page data (i.e. +page.ts) so each page can have custom actions or custom data to be copied