### PR TITLE
style: add light theme

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -147,9 +147,11 @@
 	--color-outline: oklch(from var(--color-surface) 0.65 c h);
 	--color-outline-variant: oklch(from var(--color-surface) 0.4 c h);
 
-	--color-surface: oklch(
-		from color-mix(in oklab, var(--color-shark-950) 100%, var(--color-primary) 1.5%) l c h
-	);
+	/* --color-surface: oklch( */
+	/* 	from color-mix(in oklab, var(--color-shark-950) 100%, var(--color-primary) 1.5%) l c h */
+	/* ); */
+
+	--color-surface: oklch(from var(--color-primary) 0.24 0.001 h);
 	--color-on-surface: oklch(from var(--color-surface) 0.95 c h);
 	--color-on-surface-variant: oklch(from var(--color-surface) 0.8 calc(c * 2) h);
 
@@ -216,18 +218,30 @@
 
 	[data-theme='telos'] {
 		--theme-seed: rgb(207 189 254);
+		&[data-scheme='dark'] {
+			--color-surface: oklch(from var(--color-primary) 0.24 0.02 h);
+		}
 	}
 
 	[data-theme='jungle4'] {
 		--theme-seed: #2e9e87;
+		&[data-scheme='dark'] {
+			--color-surface: oklch(from var(--color-primary) 0.24 0.005 h);
+		}
 	}
 
 	[data-theme='vaulta'] {
 		--theme-seed: #2e3bff;
+		&[data-scheme='dark'] {
+			--color-surface: oklch(from var(--color-primary) 0.24 0.02 h);
+		}
 	}
 
 	[data-theme='wax'] {
 		--theme-seed: rgb(255 183 123);
+		&[data-scheme='dark'] {
+			--color-surface: oklch(from var(--color-primary) 0.24 0.001 h);
+		}
 	}
 
 	[data-theme='kylin'] {

--- a/src/app.css
+++ b/src/app.css
@@ -92,23 +92,27 @@
 	--color-solar-900: #7c3b0b;
 	--color-solar-950: #481d00;
 
-	/* Seeds - Not for general use */
-	--color-seed: var(--color-sky-500);
-	/* --color-neutral-seed: oklch(from var(--color-seed) l 0.01 h); */
-	/* --color-neutral-variant-seed: oklch(from var(--color-seed) l 0.015 h); */
+	--theme-seed: var(--color-sky-500);
 
 	/* Color Roles and default dark values */
-	--color-primary: oklch(from var(--color-seed) 0.82 c h);
-	--color-primary-hover: oklch(from var(--color-seed) 0.9 c h);
-	--color-on-primary: oklch(from var(--color-seed) 0.2 c h);
+	--color-primary: oklch(from var(--theme-seed) 0.82 c h);
+	--color-primary-hover: oklch(from var(--theme-seed) 0.9 c h);
+	--color-on-primary: oklch(from var(--theme-seed) 0.2 c h);
 
-	--color-primary-container: oklch(from var(--color-seed) 0.39 0.086 h);
-	--color-on-primary-container: oklch(from var(--color-seed) 0.9 0.085 h);
+	--color-primary-container: oklch(from var(--theme-seed) 0.39 0.086 h);
+	--color-on-primary-container: oklch(from var(--theme-seed) 0.9 0.085 h);
 
-	--color-error: rgb(255 180 171);
-	--color-on-error: rgb(105 0 5);
-	--color-error-container: rgb(147 0 10);
-	--color-on-error-container: rgb(255 218 214);
+	--error-hue: 27;
+	--color-error: oklch(0.84 0.089 var(--error-hue));
+	--color-on-error: oklch(0.33 0.134 var(--error-hue));
+	--color-error-container: oklch(0.42 0.17 var(--error-hue));
+	--color-on-error-container: oklch(0.92 0.042 var(--error-hue));
+
+	--success-hue: 152;
+	--color-success: oklch(0.84 0.089 var(--success-hue));
+	--color-on-success: oklch(0.33 0.134 var(--success-hue));
+	--color-success-container: oklch(0.42 0.17 var(--success-hue));
+	--color-on-success-container: oklch(0.92 0.042 var(--success-hue));
 
 	--color-shadow: oklch(0 0 0);
 	--color-scrim: oklch(0 0 0 / 0.5);
@@ -150,31 +154,73 @@
 	}
 
 	[data-theme='eos'] {
-		--color-seed: rgb(248 187 113);
+		--theme-seed: rgb(248 187 113);
 	}
 
 	[data-theme='telos'] {
-		--color-seed: rgb(207 189 254);
+		--theme-seed: rgb(207 189 254);
 	}
 
 	[data-theme='jungle4'] {
-		--color-seed: #2e9e87;
+		--theme-seed: #2e9e87;
 	}
 
 	[data-theme='vaulta'] {
-		--color-seed: #2e3bff;
+		--theme-seed: #2e3bff;
 	}
 
 	[data-theme='wax'] {
-		--color-seed: rgb(255 183 123);
+		--theme-seed: rgb(255 183 123);
 	}
 
 	[data-theme='kylin'] {
-		--color-seed: rgb(255 180 168);
+		--theme-seed: rgb(255 180 168);
 	}
 
-	/* Light Mode Themes */
-	@media (prefers-color-scheme: light) {
+	[data-theme] {
+		/* Light Mode Themes */
+		@media (prefers-color-scheme: light) {
+			--color-primary: oklch(from var(--theme-seed) 0.4 c h);
+			--color-primary-hover: oklch(from var(--theme-seed) 0.9 c h);
+			--color-on-primary: oklch(from var(--theme-seed) 1 0 h);
+
+			--color-primary-container: oklch(from var(--theme-seed) 0.9 0.086 h);
+			--color-on-primary-container: oklch(from var(--theme-seed) 0.218 0.085 h);
+
+			--color-error: oklch(0.51 0.1927 var(--error-hue));
+			--color-on-error: oklch(1 0 var(--error-hue));
+			--color-error-container: oklch(0.92 0.042 var(--error-hue));
+			--color-on-error-container: oklch(0.42 0.17 var(--error-hue));
+
+			--color-success: oklch(0.51 0.1927 var(--success-hue));
+			--color-on-success: oklch(1 0 var(--success-hue));
+			--color-success-container: oklch(0.92 0.042 var(--success-hue));
+			--color-on-success-container: oklch(0.42 0.17 var(--success-hue));
+
+			--color-shadow: oklch(0 0 0);
+			--color-scrim: oklch(0 0 0 / 0.5);
+
+			--color-surface-tint: var(--color-primary);
+			--color-surface: oklch(
+				from color-mix(in oklab, var(--color-shark-50) 100%, var(--color-surface-tint) 2.3%) 0.98 c
+					h
+			);
+			--color-on-surface: oklch(from var(--color-surface) 0.22 c h);
+			--color-on-surface-variant: oklch(from var(--color-surface) 0.4 0.015 h);
+
+			--color-background: var(--color-surface);
+			--color-on-background: var(--color-on-surface);
+
+			--color-outline: oklch(from var(--color-surface) 0.5664 c h);
+			--color-outline-variant: oklch(from var(--color-surface) 0.8267 c h);
+
+			/* Surface Containers ranked by emphasis (contrast) */
+			--color-surface-container-lowest: oklch(from var(--color-surface) 1 c h);
+			--color-surface-container-low: oklch(from var(--color-surface) 0.97 c h);
+			--color-surface-container: oklch(from var(--color-surface) 0.95 c h);
+			--color-surface-container-high: oklch(from var(--color-surface) 0.93 c h);
+			--color-surface-container-highest: oklch(from var(--color-surface) 0.91 c h);
+		}
 	}
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -185,15 +185,15 @@
 	--color-outline: oklch(from var(--color-surface) 0.5664 c h);
 	--color-outline-variant: oklch(from var(--color-surface) 0.8267 c h);
 
-	--color-surface: oklch(from var(--color-primary) 0.98 0.0076 h);
+	--color-surface: oklch(from var(--color-primary) 0.98 0.007 h);
 	--color-on-surface: oklch(from var(--color-surface) 0.22 c h);
 	--color-on-surface-variant: oklch(from var(--color-surface) 0.4 0.015 h);
 
-	--color-surface-container-lowest: oklch(from var(--color-surface) calc(l + 0.01) c h);
-	--color-surface-container-low: oklch(from var(--color-surface) calc(l - 0.01) c h);
-	--color-surface-container: oklch(from var(--color-surface) calc(l - 0.023) c h);
-	--color-surface-container-high: oklch(from var(--color-surface) calc(l - 0.05) c h);
-	--color-surface-container-highest: oklch(from var(--color-surface) calc(l - 0.1) c h);
+	--color-surface-container-lowest: oklch(from var(--color-surface) calc(l + 0.01) 0.01 h);
+	--color-surface-container-low: oklch(from var(--color-surface) calc(l - 0.01) 0.01 h);
+	--color-surface-container: oklch(from var(--color-surface) calc(l - 0.023) 0.01 h);
+	--color-surface-container-high: oklch(from var(--color-surface) calc(l - 0.05) 0.01 h);
+	--color-surface-container-highest: oklch(from var(--color-surface) calc(l - 0.1) 0.01 h);
 
 	--color-background: var(--color-surface);
 	--color-on-background: var(--color-on-surface);

--- a/src/app.css
+++ b/src/app.css
@@ -92,9 +92,41 @@
 	--color-solar-900: #7c3b0b;
 	--color-solar-950: #481d00;
 
-	--theme-seed: var(--color-sky-500);
+	--error-hue: 27;
+	--success-hue: 152;
 
-	/* Color Roles and default dark values */
+	--color-primary: inherit;
+	--color-primary-hover: inherit;
+	--color-on-primary: inherit;
+	--color-primary-container: inherit;
+	--color-on-primary-container: inherit;
+	--color-error: inherit;
+	--color-on-error: inherit;
+	--color-error-container: inherit;
+	--color-on-error-container: inherit;
+	--color-success: inherit;
+	--color-on-success: inherit;
+	--color-success-container: inherit;
+	--color-on-success-container: inherit;
+
+	--color-shadow: oklch(0 0 0);
+	--color-scrim: oklch(0 0 0 / 0.5);
+
+	--color-outline: inherit;
+	--color-outline-variant: inherit;
+	--color-surface: inherit;
+	--color-on-surface: inherit;
+	--color-on-surface-variant: inherit;
+	--color-surface-container-lowest: inherit;
+	--color-surface-container-low: inherit;
+	--color-surface-container: inherit;
+	--color-surface-container-high: inherit;
+	--color-surface-container-highest: inherit;
+	--color-background: inherit;
+	--color-on-background: inherit;
+}
+
+@utility dark-scheme {
 	--color-primary: oklch(from var(--theme-seed) 0.82 c h);
 	--color-primary-hover: oklch(from var(--theme-seed) 0.9 c h);
 	--color-on-primary: oklch(from var(--theme-seed) 0.2 c h);
@@ -102,30 +134,24 @@
 	--color-primary-container: oklch(from var(--theme-seed) 0.39 0.086 h);
 	--color-on-primary-container: oklch(from var(--theme-seed) 0.9 0.085 h);
 
-	--error-hue: 27;
 	--color-error: oklch(0.84 0.089 var(--error-hue));
 	--color-on-error: oklch(0.33 0.134 var(--error-hue));
 	--color-error-container: oklch(0.42 0.17 var(--error-hue));
 	--color-on-error-container: oklch(0.92 0.042 var(--error-hue));
 
-	--success-hue: 152;
 	--color-success: oklch(0.84 0.089 var(--success-hue));
 	--color-on-success: oklch(0.33 0.134 var(--success-hue));
 	--color-success-container: oklch(0.42 0.17 var(--success-hue));
 	--color-on-success-container: oklch(0.92 0.042 var(--success-hue));
 
-	--color-shadow: oklch(0 0 0);
-	--color-scrim: oklch(0 0 0 / 0.5);
-
-	--color-surface: color-mix(in oklab, var(--color-shark-950) 100%, var(--color-primary) 1.5%);
-	--color-background: var(--color-surface);
-
-	--color-on-surface: oklch(from var(--color-surface) 0.95 c h);
-	--color-on-surface-variant: oklch(from var(--color-surface) 0.8 calc(c * 2) h);
-	--color-on-background: var(--color-on-surface);
-
 	--color-outline: oklch(from var(--color-surface) 0.65 c h);
 	--color-outline-variant: oklch(from var(--color-surface) 0.4 c h);
+
+	--color-surface: oklch(
+		from color-mix(in oklab, var(--color-shark-950) 100%, var(--color-primary) 1.5%) l c h
+	);
+	--color-on-surface: oklch(from var(--color-surface) 0.95 c h);
+	--color-on-surface-variant: oklch(from var(--color-surface) 0.8 calc(c * 2) h);
 
 	/* Surface Containers ranked by emphasis (contrast) */
 	--color-surface-container-lowest: oklch(from var(--color-surface) calc(l - 0.01) c h);
@@ -133,45 +159,57 @@
 	--color-surface-container: oklch(from var(--color-surface) calc(l + 0.023) c h);
 	--color-surface-container-high: oklch(from var(--color-surface) calc(l + 0.05) c h);
 	--color-surface-container-highest: oklch(from var(--color-surface) calc(l + 0.1) c h);
+
+	--color-background: var(--color-surface);
+	--color-on-background: var(--color-on-surface);
 }
 
-/*
-  The default border color has changed to `currentColor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
+@utility light-scheme {
+	--color-primary: oklch(from var(--theme-seed) 0.4 c h);
+	--color-primary-hover: oklch(from var(--theme-seed) 0.5 c h);
+	--color-on-primary: oklch(from var(--theme-seed) 1 0 h);
 
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
-*/
+	--color-primary-container: oklch(from var(--theme-seed) 0.9 0.086 h);
+	--color-on-primary-container: oklch(from var(--theme-seed) 0.218 0.085 h);
+
+	--color-error: oklch(0.51 0.1927 var(--error-hue));
+	--color-on-error: oklch(1 0 var(--error-hue));
+	--color-error-container: oklch(0.92 0.042 var(--error-hue));
+	--color-on-error-container: oklch(0.42 0.17 var(--error-hue));
+
+	--color-success: oklch(0.51 0.1927 var(--success-hue));
+	--color-on-success: oklch(1 0 var(--success-hue));
+	--color-success-container: oklch(0.92 0.042 var(--success-hue));
+	--color-on-success-container: oklch(0.42 0.17 var(--success-hue));
+
+	--color-outline: oklch(from var(--color-surface) 0.5664 c h);
+	--color-outline-variant: oklch(from var(--color-surface) 0.8267 c h);
+
+	--color-surface: oklch(from var(--color-primary) 0.98 0.0076 h);
+	--color-on-surface: oklch(from var(--color-surface) 0.22 c h);
+	--color-on-surface-variant: oklch(from var(--color-surface) 0.4 0.015 h);
+
+	--color-surface-container-lowest: oklch(from var(--color-surface) calc(l + 0.01) c h);
+	--color-surface-container-low: oklch(from var(--color-surface) calc(l - 0.01) c h);
+	--color-surface-container: oklch(from var(--color-surface) calc(l - 0.023) c h);
+	--color-surface-container-high: oklch(from var(--color-surface) calc(l - 0.05) c h);
+	--color-surface-container-highest: oklch(from var(--color-surface) calc(l - 0.1) c h);
+
+	--color-background: var(--color-surface);
+	--color-on-background: var(--color-on-surface);
+}
+
 @layer base {
-	*,
-	::after,
-	::before,
-	::backdrop,
-	::file-selector-button {
-		border-color: var(--color-outline, currentColor);
+	/* Schemes */
+	[data-scheme='light'] {
+		@apply light-scheme;
 	}
 
-	html {
-		@apply bg-background text-on-background h-full;
-		color-scheme: dark light;
-		touch-action: manipulation;
-		scrollbar-gutter: stable;
-
-		::selection {
-			@apply bg-primary text-on-primary;
-		}
+	[data-scheme='dark'] {
+		@apply dark-scheme;
 	}
 
-	body {
-		@apply h-auto min-h-svh;
-	}
-
-	p,
-	li {
-		@apply text-muted text-base font-normal;
-	}
-
+	/* Themes */
 	[data-theme='eos'] {
 		--theme-seed: rgb(248 187 113);
 	}
@@ -196,50 +234,29 @@
 		--theme-seed: rgb(255 180 168);
 	}
 
-	[data-theme] {
-		@media (prefers-color-scheme: light) {
-			--color-primary: oklch(from var(--theme-seed) 0.4 c h);
-			--color-primary-hover: oklch(from var(--theme-seed) 0.9 c h);
-			--color-on-primary: oklch(from var(--theme-seed) 1 0 h);
+	/* Element defaults */
+	:root {
+		@apply bg-background text-on-background h-full;
+		color-scheme: dark light;
+		touch-action: manipulation;
+		scrollbar-gutter: stable;
 
-			--color-primary-container: oklch(from var(--theme-seed) 0.9 0.086 h);
-			--color-on-primary-container: oklch(from var(--theme-seed) 0.218 0.085 h);
-
-			--color-error: oklch(0.51 0.1927 var(--error-hue));
-			--color-on-error: oklch(1 0 var(--error-hue));
-			--color-error-container: oklch(0.92 0.042 var(--error-hue));
-			--color-on-error-container: oklch(0.42 0.17 var(--error-hue));
-
-			--color-success: oklch(0.51 0.1927 var(--success-hue));
-			--color-on-success: oklch(1 0 var(--success-hue));
-			--color-success-container: oklch(0.92 0.042 var(--success-hue));
-			--color-on-success-container: oklch(0.42 0.17 var(--success-hue));
-
-			--color-shadow: oklch(0 0 0);
-			--color-scrim: oklch(0 0 0 / 0.5);
-
-			--color-surface: oklch(from var(--color-primary) 0.92 0.0076 h);
-			--color-on-surface: oklch(from var(--color-surface) 0.22 c h);
-			--color-on-surface-variant: oklch(from var(--color-surface) 0.4 0.015 h);
-
-			--color-background: var(--color-surface);
-			--color-on-background: var(--color-on-surface);
-
-			--color-outline: oklch(from var(--color-surface) 0.5664 c h);
-			--color-outline-variant: oklch(from var(--color-surface) 0.8267 c h);
-
-			/* Surface Containers ranked by emphasis (contrast) */
-			--color-surface-container-lowest: oklch(from var(--color-surface) 0.9 c h);
-			--color-surface-container-low: oklch(from var(--color-surface) 0.935 c h);
-			--color-surface-container: oklch(from var(--color-surface) 0.955 c h);
-			--color-surface-container-high: oklch(from var(--color-surface) 0.975 c h);
-			--color-surface-container-highest: oklch(from var(--color-surface) 1 c h);
+		::selection {
+			@apply bg-primary text-on-primary;
 		}
+	}
+
+	body {
+		@apply h-auto min-h-svh;
+	}
+
+	p,
+	li {
+		@apply text-muted text-base font-normal;
 	}
 }
 
 @utility h1 {
-	/* Headings are defined by class instead of tag to preserve semantic html independent of style */
 	@apply text-5xl leading-none font-semibold;
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -117,8 +117,7 @@
 	--color-shadow: oklch(0 0 0);
 	--color-scrim: oklch(0 0 0 / 0.5);
 
-	--color-surface-tint: var(--color-primary);
-	--color-surface: color-mix(in oklab, var(--color-shark-950) 100%, var(--color-surface-tint) 1.5%);
+	--color-surface: color-mix(in oklab, var(--color-shark-950) 100%, var(--color-primary) 1.5%);
 	--color-background: var(--color-surface);
 
 	--color-on-surface: oklch(from var(--color-surface) 0.95 c h);
@@ -153,6 +152,26 @@
 		border-color: var(--color-outline, currentColor);
 	}
 
+	html {
+		@apply bg-background text-on-background h-full;
+		color-scheme: dark light;
+		touch-action: manipulation;
+		scrollbar-gutter: stable;
+
+		::selection {
+			@apply bg-primary text-on-primary;
+		}
+	}
+
+	body {
+		@apply h-auto min-h-svh;
+	}
+
+	p,
+	li {
+		@apply text-muted text-base font-normal;
+	}
+
 	[data-theme='eos'] {
 		--theme-seed: rgb(248 187 113);
 	}
@@ -178,7 +197,6 @@
 	}
 
 	[data-theme] {
-		/* Light Mode Themes */
 		@media (prefers-color-scheme: light) {
 			--color-primary: oklch(from var(--theme-seed) 0.4 c h);
 			--color-primary-hover: oklch(from var(--theme-seed) 0.9 c h);
@@ -200,11 +218,7 @@
 			--color-shadow: oklch(0 0 0);
 			--color-scrim: oklch(0 0 0 / 0.5);
 
-			--color-surface-tint: var(--color-primary);
-			--color-surface: oklch(
-				from color-mix(in oklab, var(--color-shark-50) 100%, var(--color-surface-tint) 2.3%) 0.98 c
-					h
-			);
+			--color-surface: oklch(from var(--color-primary) 0.96 0.0076 h);
 			--color-on-surface: oklch(from var(--color-surface) 0.22 c h);
 			--color-on-surface-variant: oklch(from var(--color-surface) 0.4 0.015 h);
 
@@ -215,11 +229,11 @@
 			--color-outline-variant: oklch(from var(--color-surface) 0.8267 c h);
 
 			/* Surface Containers ranked by emphasis (contrast) */
-			--color-surface-container-lowest: oklch(from var(--color-surface) 1 c h);
-			--color-surface-container-low: oklch(from var(--color-surface) 0.97 c h);
-			--color-surface-container: oklch(from var(--color-surface) 0.95 c h);
-			--color-surface-container-high: oklch(from var(--color-surface) 0.93 c h);
-			--color-surface-container-highest: oklch(from var(--color-surface) 0.91 c h);
+			--color-surface-container-lowest: oklch(from var(--color-surface) 0.96 c h);
+			--color-surface-container-low: oklch(from var(--color-surface) 0.96 c h);
+			--color-surface-container: oklch(from var(--color-surface) 0.96 c h);
+			--color-surface-container-high: oklch(from var(--color-surface) 0.98 c h);
+			--color-surface-container-highest: oklch(from var(--color-surface) 1 c h);
 		}
 	}
 }
@@ -281,7 +295,6 @@
 }
 
 @utility table-styles {
-	/* table styles */
 	:where(&) {
 		@apply w-full table-auto overflow-x-auto;
 
@@ -335,23 +348,4 @@
 }
 
 @layer components {
-	html {
-		@apply bg-background text-on-background h-full;
-		color-scheme: dark light;
-		touch-action: manipulation;
-		scrollbar-gutter: stable;
-
-		::selection {
-			@apply bg-primary text-on-primary;
-		}
-	}
-
-	body {
-		@apply h-auto min-h-svh;
-	}
-
-	p,
-	li {
-		@apply text-muted text-base font-normal;
-	}
 }

--- a/src/app.css
+++ b/src/app.css
@@ -218,7 +218,7 @@
 			--color-shadow: oklch(0 0 0);
 			--color-scrim: oklch(0 0 0 / 0.5);
 
-			--color-surface: oklch(from var(--color-primary) 0.96 0.0076 h);
+			--color-surface: oklch(from var(--color-primary) 0.92 0.0076 h);
 			--color-on-surface: oklch(from var(--color-surface) 0.22 c h);
 			--color-on-surface-variant: oklch(from var(--color-surface) 0.4 0.015 h);
 
@@ -229,10 +229,10 @@
 			--color-outline-variant: oklch(from var(--color-surface) 0.8267 c h);
 
 			/* Surface Containers ranked by emphasis (contrast) */
-			--color-surface-container-lowest: oklch(from var(--color-surface) 0.96 c h);
-			--color-surface-container-low: oklch(from var(--color-surface) 0.96 c h);
-			--color-surface-container: oklch(from var(--color-surface) 0.96 c h);
-			--color-surface-container-high: oklch(from var(--color-surface) 0.98 c h);
+			--color-surface-container-lowest: oklch(from var(--color-surface) 0.9 c h);
+			--color-surface-container-low: oklch(from var(--color-surface) 0.935 c h);
+			--color-surface-container: oklch(from var(--color-surface) 0.955 c h);
+			--color-surface-container-high: oklch(from var(--color-surface) 0.975 c h);
 			--color-surface-container-highest: oklch(from var(--color-surface) 1 c h);
 		}
 	}

--- a/src/app.html
+++ b/src/app.html
@@ -6,12 +6,11 @@
 			name="viewport"
 			content="width=device-width, initial-scale=1, interactive-widget=resizes-content"
 		/>
-		<meta name="color-scheme" content="dark" />
+		<meta name="color-scheme" content="dark light" />
 		<link rel="icon" href="/favicon.ico" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" sizes="any" />
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 		<meta name="apple-mobile-web-app-title" content="Unicove" />
-		<!-- <link rel="manifest" href="/site.webmanifest" /> -->
 		<style>
 			@font-face {
 				font-family: 'Inter';

--- a/src/lib/components/banner/pageBanner.svelte
+++ b/src/lib/components/banner/pageBanner.svelte
@@ -41,7 +41,7 @@
 
 {#if showBanner}
 	<aside
-		class="grid grid-cols-[auto_1fr_auto] items-center justify-items-center gap-4 bg-linear-to-r from-[#1C2399] to-[#2E3BFF] text-white shadow-lg *:row-start-1"
+		class="text-white grid grid-cols-[auto_1fr_auto] items-center justify-items-center gap-4 bg-linear-to-r from-[#1C2399] to-[#2E3BFF] shadow-lg *:row-start-1"
 	>
 		<a
 			class="col-start-2 py-4 text-white underline underline-offset-4 md:col-span-3 md:col-start-1 md:text-center"

--- a/src/lib/components/banner/pageBanner.svelte
+++ b/src/lib/components/banner/pageBanner.svelte
@@ -41,7 +41,7 @@
 
 {#if showBanner}
 	<aside
-		class="text-white grid grid-cols-[auto_1fr_auto] items-center justify-items-center gap-4 bg-linear-to-r from-[#1C2399] to-[#2E3BFF] shadow-lg *:row-start-1"
+		class="grid grid-cols-[auto_1fr_auto] items-center justify-items-center gap-4 bg-linear-to-r from-[#1C2399] to-[#2E3BFF] text-white shadow-lg *:row-start-1"
 	>
 		<a
 			class="col-start-2 py-4 text-white underline underline-offset-4 md:col-span-3 md:col-start-1 md:text-center"

--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -49,7 +49,7 @@
 		' inline-flex h-12 grow  rounded-lg bg-primary px-8  text-on-primary  focus:outline-transparent focus-visible:outline focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-solar-500 disabled:bg-on-surface/12 disabled:text-on-surface/40';
 
 	const outlinedStyles =
-		' flex h-12 grow  rounded-lg px-8  text-primary ring-2 ring-inset ring-outline   focus-visible:outline-hidden focus-visible:ring-solar-500  hover:active:ring-outline  disabled:text-on-surface/40  disabled:hover:bg-transparent disabled:hover:ring-on-surface/12 disabled:ring-on-surface/12  ';
+		' flex h-12 grow  rounded-lg px-8  text-primary ring-2 ring-inset ring-outline-variant   focus-visible:outline-hidden focus-visible:ring-solar-500  hover:active:ring-outline-variant  disabled:text-on-surface/40  disabled:hover:bg-transparent disabled:hover:ring-on-surface/12 disabled:ring-on-surface/12  ';
 
 	const pillStyles =
 		' inline-flex h-10  rounded-full border-2 border-transparent px-5  leading-4  focus-visible:border-solar-500  focus-visible:outline-hidden   aria-[current]:border-outline-variant aria-[current]:focus-visible:border-solar-500';
@@ -81,7 +81,7 @@
 	{...linkProps}
 >
 	<div
-		class="state-layer group-active/button:group-hove/buttonr:opacity-16 pointer-events-none absolute inset-0 rounded-[inherit] bg-current opacity-0 transition-opacity group-hover/button:opacity-8 group-focus-visible/button:opacity-10 group-disabled/button:hidden"
+		class="state-layer pointer-events-none absolute inset-0 rounded-[inherit] bg-current opacity-0 transition-opacity group-hover/button:opacity-8 group-focus-visible/button:opacity-10 group-active/button:group-hover/button:opacity-16 group-disabled/button:hidden"
 	></div>
 	<span class="content-layer pointer-events-none relative text-inherit">
 		{@render props.children()}

--- a/src/lib/components/elements/account.svelte
+++ b/src/lib/components/elements/account.svelte
@@ -47,7 +47,7 @@
 <a
 	href={path}
 	class={cn(
-		'focus-visible:outline-solar-500 text-primary hover:text-primary-container inline-flex items-center gap-2 focus-visible:outline ',
+		'focus-visible:outline-solar-500 text-primary hover:text-primary-hover inline-flex items-center gap-2 focus-visible:outline ',
 		props.class
 	)}
 	use:melt={$trigger}

--- a/src/lib/components/elements/block.svelte
+++ b/src/lib/components/elements/block.svelte
@@ -9,7 +9,7 @@
 </script>
 
 {#if number}
-	<a class="text-primary hover:text-primary-container" href="/{network}/block/{String(number)}">
+	<a class="text-primary hover:text-primary-hover" href="/{network}/block/{String(number)}">
 		{String(number)}
 	</a>
 {/if}

--- a/src/lib/components/elements/contract.svelte
+++ b/src/lib/components/elements/contract.svelte
@@ -34,7 +34,7 @@
 </script>
 
 {#if name}
-	<a class={cn('text-primary hover:text-primary-container', props.class)} {href}>
+	<a class={cn('text-primary hover:text-primary-hover', props.class)} {href}>
 		{#if children}
 			{@render children()}
 		{:else}

--- a/src/lib/components/elements/key.svelte
+++ b/src/lib/components/elements/key.svelte
@@ -16,7 +16,7 @@
 
 {#if key}
 	<a
-		class="text-primary hover:text-primary-container inline-grid grid-cols-[auto_1fr] items-start gap-2 font-mono"
+		class="text-primary hover:text-primary-hover inline-grid grid-cols-[auto_1fr] items-start gap-2 font-mono"
 		href="/{network}/key/{String(key)}"
 	>
 		{#if icon}

--- a/src/lib/components/elements/tradingpair.svelte
+++ b/src/lib/components/elements/tradingpair.svelte
@@ -47,12 +47,12 @@
 	</span>
 	{#if historic}
 		{#if percentChangePositive}
-			<span class="inline-flex items-center gap-1.5 leading-none text-green-300">
+			<span class="text-success inline-flex items-center gap-1.5 leading-none">
 				<Triangle fill="currentColor" class="size-2" />
 				{percentChangeString}% {timeframeString}
 			</span>
 		{:else}
-			<span class="inline-flex items-center gap-1.5 leading-none text-red-300">
+			<span class="text-error inline-flex items-center gap-1.5 leading-none">
 				<Triangle fill="currentColor" class="size-2 rotate-180" />
 				{percentChangeString}% {timeframeString}
 			</span>

--- a/src/lib/components/elements/transaction.svelte
+++ b/src/lib/components/elements/transaction.svelte
@@ -13,7 +13,7 @@
 
 {#if id}
 	<a
-		class={cn('text-primary hover:text-primary-container', className)}
+		class={cn('text-primary hover:text-primary-hover', className)}
 		href="/{network}/transaction/{String(id)}"
 	>
 		{truncatedString}

--- a/src/lib/components/input/switch.svelte
+++ b/src/lib/components/input/switch.svelte
@@ -46,7 +46,7 @@
 	<button
 		{id}
 		use:melt={$root}
-		class=" border-outline *:bg-outline focus-visible:border-solar-500 focus-visible:outline-solar-500 data-[state=checked]:*:bg-on-primary-container data-[state=checked]:bg-primary-container data-[state=checked]:border-primary-container data-[state=checked]:hover:bg-primary-container/90 data-[state=checked]:hover:border-primary-container/90 relative h-8 w-[52px] rounded-full border-2 bg-transparent *:size-4 *:translate-x-1.5 *:transition-transform focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] disabled:cursor-not-allowed disabled:opacity-40 data-[state=checked]:*:translate-x-[26px] data-[state=checked]:*:scale-150"
+		class=" border-outline *:bg-outline focus-visible:border-solar-500 focus-visible:outline-solar-500 data-[state=checked]:*:bg-on-primary data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:hover:bg-primary/90 data-[state=checked]:hover:border-primary/90 relative h-8 w-[52px] rounded-full border-2 bg-transparent *:size-4 *:translate-x-1.5 *:transition-transform focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] disabled:cursor-not-allowed disabled:opacity-40 data-[state=checked]:*:translate-x-[26px] data-[state=checked]:*:scale-150"
 		aria-labelledby={ariaLabelledBy}
 	>
 		<span class="thumb block rounded-full"></span>

--- a/src/lib/components/navigation/sidemenu.svelte
+++ b/src/lib/components/navigation/sidemenu.svelte
@@ -79,7 +79,7 @@
 		<a
 			href={option.href}
 			class="focus-visible:outline-solar-500 flex h-12 items-center rounded-lg leading-snug transition-opacity select-none hover:opacity-100 focus-visible:opacity-100 focus-visible:outline"
-			class:opacity-60={!option.active}
+			class:opacity-70={!option.active}
 			class:opacity-100={option.active}
 			aria-current={!!option.active}
 			onclick={callbackFn}

--- a/src/lib/components/select/elements/item.svelte
+++ b/src/lib/components/select/elements/item.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <div
-	class=" hover:bg-primary focus:text-on-primary data-highlighted:bg-primary data-highlighted:text-on-primary relative grid cursor-pointer grid-cols-[auto_1fr] items-center gap-2 rounded-xl px-2 py-1 font-medium hover:text-black/95 focus:z-10 data-disabled:opacity-50 data-[variant=form]:rounded-xs data-[variant=pill]:rounded-xl"
+	class=" hover:bg-primary focus:text-on-primary data-highlighted:bg-primary data-highlighted:text-on-primary hover:text-on-primary relative grid cursor-pointer grid-cols-[auto_1fr] items-center gap-2 rounded-xl px-2 py-1 font-medium focus:z-10 data-disabled:opacity-50 data-[variant=form]:rounded-xs data-[variant=pill]:rounded-xl"
 	data-variant={props.variant}
 	use:melt={$option(props.item)}
 >

--- a/src/routes/[network]/(account)/staking/+page.svelte
+++ b/src/routes/[network]/(account)/staking/+page.svelte
@@ -78,7 +78,7 @@
 
 {#snippet tableAction([text, href]: string[])}
 	<td class="text-right">
-		<a class="text-primary hover:text-primary-container" {href}>{text}</a>
+		<a class="text-primary hover:text-primary-hover" {href}>{text}</a>
 	</td>
 {/snippet}
 

--- a/src/routes/[network]/(dev)/debug/components/sections/colors.svelte
+++ b/src/routes/[network]/(dev)/debug/components/sections/colors.svelte
@@ -2,7 +2,7 @@
 	import { Stack } from '$lib/components/layout';
 </script>
 
-<Stack id="colors" class="rounded-xl bg-black/10  p-6">
+<Stack id="colors" class="bg-surface-container rounded-xl  p-6">
 	<h2 class="h2">Color Roles</h2>
 
 	<div>
@@ -50,6 +50,32 @@
 					</div>
 				</div>
 			</div>
+		</div>
+
+		<div class="bg-error min-h-20 p-4">
+			<span class="text-on-error font-bold">error</span>
+		</div>
+		<div class="bg-on-error min-h-20 p-4">
+			<span class="text-error font-bold">On error</span>
+		</div>
+		<div class="bg-error-container min-h-20 p-4">
+			<span class="text-on-error-container font-bold">error Container</span>
+		</div>
+		<div class="bg-on-error-container min-h-20 p-4">
+			<span class="text-error-container font-bold">On error Container</span>
+		</div>
+
+		<div class="bg-success min-h-20 p-4">
+			<span class="text-on-success font-bold">success</span>
+		</div>
+		<div class="bg-on-success min-h-20 p-4">
+			<span class="text-success font-bold">On success</span>
+		</div>
+		<div class="bg-success-container min-h-20 p-4">
+			<span class="text-on-success-container font-bold">success Container</span>
+		</div>
+		<div class="bg-on-success-container min-h-20 p-4">
+			<span class="text-success-container font-bold">On success Container</span>
 		</div>
 	</div>
 </Stack>

--- a/src/routes/[network]/+layout.svelte
+++ b/src/routes/[network]/+layout.svelte
@@ -215,12 +215,14 @@
 	<!-- Init color scheme on page load -->
 	<script>
 		(function () {
-			const storedTheme = localStorage.getItem('color-scheme');
-			const theme =
-				storedTheme ||
-				(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-			document.documentElement.setAttribute('data-scheme', theme);
-			if (!storedTheme) localStorage.setItem('color-scheme', theme);
+			if (typeof window !== undefined) {
+				const storedTheme = localStorage.getItem('color-scheme');
+				const theme =
+					storedTheme ||
+					(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+				document.documentElement.setAttribute('data-scheme', theme);
+				if (!storedTheme) localStorage.setItem('color-scheme', theme);
+			}
 		})();
 	</script>
 </svelte:head>

--- a/src/routes/[network]/+layout.svelte
+++ b/src/routes/[network]/+layout.svelte
@@ -208,9 +208,21 @@
 
 <Head {seo_config} />
 
-<!-- Preload current chain logo -->
 <svelte:head>
+	<!-- Preload current chain logo -->
 	<link rel="preload" href={String(data.network.config.logo)} as="image" type="image/png" />
+
+	<!-- Init color scheme on page load -->
+	<script>
+		(function () {
+			const storedTheme = localStorage.getItem('color-scheme');
+			const theme =
+				storedTheme ||
+				(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+			document.documentElement.setAttribute('data-scheme', theme);
+			if (!storedTheme) localStorage.setItem('color-scheme', theme);
+		})();
+	</script>
 </svelte:head>
 
 <div

--- a/src/routes/[network]/settings/+page.svelte
+++ b/src/routes/[network]/settings/+page.svelte
@@ -183,7 +183,7 @@
 
 			<div class="flex items-center justify-between">
 				<Stack class="gap-2">
-					<Label for="proposal-expiration">Increased Precision</Label>
+					<Label for="increased-precision">Increased Precision</Label>
 					<p class="caption text-sm">Use more decimals to increase currency precision.</p>
 				</Stack>
 				<Switch id="increased-precision" bind:checked={increasedPrecision} />

--- a/src/routes/[network]/settings/+page.svelte
+++ b/src/routes/[network]/settings/+page.svelte
@@ -20,6 +20,7 @@
 	import { availableLanguageTags } from '$lib/paraglide/runtime';
 	import CurrencySelect from '$lib/components/select/currency.svelte';
 	import DebugToggle from '$lib/components/select/debug.svelte';
+	import type { CreateSwitchProps } from '@melt-ui/svelte';
 
 	const context = getContext<UnicoveContext>('state');
 
@@ -30,6 +31,7 @@
 	let developerMode = $state(!!context.settings.data.developerMode);
 	let mockPrice = $state(!!context.settings.data.mockPrice);
 	let increasedPrecision = $state(!!context.settings.data.increasedPrecision);
+	let darkMode = $state(localStorage.getItem('color-scheme') === 'dark');
 
 	let refEarliestExecution: DatetimeInput | undefined = $state();
 
@@ -104,6 +106,17 @@
 		refEarliestExecution?.set(undefined);
 		context.wharf.setWalletSetting('earliestExecution', undefined);
 	}
+
+	const onDarkModeToggle: CreateSwitchProps['onCheckedChange'] = ({ next }) => {
+		if (darkMode && localStorage.getItem('color-scheme') == 'light') {
+			localStorage.setItem('color-scheme', 'dark');
+			document.documentElement.setAttribute('data-scheme', 'dark');
+		} else if (!darkMode && localStorage.getItem('color-scheme') === 'dark') {
+			localStorage.setItem('color-scheme', 'light');
+			document.documentElement.setAttribute('data-scheme', 'light');
+		}
+		return next;
+	};
 </script>
 
 <Stack tag="article" class="gap-6">
@@ -187,6 +200,16 @@
 					<p class="caption text-sm">Use more decimals to increase currency precision.</p>
 				</Stack>
 				<Switch id="increased-precision" bind:checked={increasedPrecision} />
+			</div>
+
+			<div class="flex items-center justify-between">
+				<Stack class="gap-2">
+					<Label for="color-scheme">Dark Mode</Label>
+					<p class="caption text-sm text-balance">
+						Toggle site wide dark mode independent from operating system preferences.
+					</p>
+				</Stack>
+				<Switch id="color-scheme" onCheckedChange={onDarkModeToggle} bind:checked={darkMode} />
 			</div>
 		</Card>
 

--- a/src/routes/[network]/settings/+page.svelte
+++ b/src/routes/[network]/settings/+page.svelte
@@ -2,6 +2,7 @@
 	import { BlockTimestamp } from '@wharfkit/antelope';
 	import { getContext } from 'svelte';
 	import type { ChangeFn } from '@melt-ui/svelte/internal/helpers';
+	import { browser } from '$app/environment';
 
 	import Switch from '$lib/components/input/switch.svelte';
 	import LanguageSelect from '$lib/components/select/language.svelte';
@@ -31,7 +32,7 @@
 	let developerMode = $state(!!context.settings.data.developerMode);
 	let mockPrice = $state(!!context.settings.data.mockPrice);
 	let increasedPrecision = $state(!!context.settings.data.increasedPrecision);
-	let darkMode = $state(localStorage.getItem('color-scheme') === 'dark');
+	let darkMode = $state(browser && localStorage.getItem('color-scheme') === 'dark');
 
 	let refEarliestExecution: DatetimeInput | undefined = $state();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,13 @@
 		"sourceMap": true,
 		"strict": true,
 		"moduleResolution": "bundler",
-		"experimentalDecorators": true
+		"experimentalDecorators": true,
+		"plugins": [
+			{
+				"name": "typescript-svelte-plugin",
+				"enabled": true
+			}
+		]
 	},
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
 	// except $lib which is handled by https://kit.svelte.dev/docs/configuration#files


### PR DESCRIPTION
Adds light mode that follows user OS preference
Adds toggle in settings to override OS preference
Adds color roles for `success` and `error`
Changes style of outlined buttons for lower contrast outline
Fixes contrast issues with sidemenu options
Fixes bug with label in settings