### PR TITLE
feat: add automatic icon for external button links

### DIFF
--- a/src/lib/components/button/button.svelte
+++ b/src/lib/components/button/button.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils';
 	import { emptyMeltElement, melt, type AnyMeltElement } from '@melt-ui/svelte';
+	import ExternalLink from 'lucide-svelte/icons/external-link';
 	import type { Snippet } from 'svelte';
 	import type { HTMLButtonAttributes, HTMLLinkAttributes } from 'svelte/elements';
 
@@ -84,5 +85,9 @@
 	></div>
 	<span class="content-layer pointer-events-none relative text-inherit">
 		{@render props.children()}
+		<ExternalLink
+			data-external={/^https?:\/\//.test(props.href || '')}
+			class="mb-1 ml-1 hidden size-4 data-[external=true]:inline"
+		/>
 	</span>
 </svelte:element>

--- a/src/routes/[network]/(homepage)/components/articles.svelte
+++ b/src/routes/[network]/(homepage)/components/articles.svelte
@@ -4,7 +4,7 @@
 	import Button from '$lib/components/button/button.svelte';
 	import IconButton from '$lib/components/button/icon.svelte';
 	import type { Article } from '$lib/types/content';
-	import { ChevronLeft, ChevronRight, Circle, ExternalLink } from 'lucide-svelte';
+	import { ChevronLeft, ChevronRight, Circle } from 'lucide-svelte';
 
 	interface Props {
 		articles: Article[];
@@ -42,7 +42,6 @@
 				<TextBlock title={article.title} text={article.description}>
 					<Button variant="primary" href={article.slug} blank>
 						{m.common_read_more()}
-						<ExternalLink class="mb-1 ml-1 inline size-4" />
 					</Button>
 				</TextBlock>
 			</div>

--- a/src/routes/[network]/(homepage)/components/staking-rewards.svelte
+++ b/src/routes/[network]/(homepage)/components/staking-rewards.svelte
@@ -7,7 +7,6 @@
 	import Box from '$lib/components/layout/box/box.svelte';
 	import * as m from '$lib/paraglide/messages';
 	import Button from '$lib/components/button/button.svelte';
-	import { ArrowRight } from 'lucide-svelte';
 
 	interface Props {
 		network: NetworkState;
@@ -41,9 +40,7 @@
 						{m.common_stake_action()}
 					</Button>
 					<Button variant="tertiary" href="https://eosnetwork.com/staking-rewards/">
-						<span class="flex items-center gap-2">
-							Learn more <ArrowRight class="size-4" />
-						</span>
+						Learn more
 					</Button>
 				</div>
 				<p class="text-muted text-xs">

--- a/src/routes/[network]/(homepage)/components/text-block.svelte
+++ b/src/routes/[network]/(homepage)/components/text-block.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/components/button/button.svelte';
 	import Stack from '$lib/components/layout/stack.svelte';
-	import { ArrowRight } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 
 	interface Props {
@@ -18,10 +17,7 @@
 	<p>{props.text}</p>
 	{#if props.button && props.button.href}
 		<Button class="-ml-3" variant="tertiary" href={props.button.href}>
-			<span class="flex items-center gap-2">
-				{props.button.text}
-				<ArrowRight class="size-4" />
-			</span>
+			{props.button.text}
 		</Button>
 	{/if}
 	{@render props.children?.()}


### PR DESCRIPTION
refactor the homepage link to be more generic and now any external link on the site (using the Button component) will have an icon indicating the user will be navigated away from unicove.com