### PR TITLE
feat: add contract upload zone

### DIFF
--- a/src/routes/[network]/(account)/upload/[[name]]/+page.svelte
+++ b/src/routes/[network]/(account)/upload/[[name]]/+page.svelte
@@ -12,6 +12,7 @@
 	import { SingleCard } from '$lib/components/layout/index.js';
 	import Stack from '$lib/components/layout/stack.svelte';
 	import Label from '$lib/components/input/label.svelte';
+	import { FileUpload } from 'unicove-components';
 
 	const { data } = $props();
 	const context = getContext<UnicoveContext>('state');
@@ -34,24 +35,21 @@
 	let id: Checksum256 | undefined = $state();
 	let error: string | undefined = $state();
 
-	function set(event: Event) {
-		const input = event.target as HTMLInputElement;
-		for (const file of input.files || []) {
-			const reader = new FileReader();
-			const extension = file.name.split('.').pop();
-			switch (extension) {
-				case 'abi':
-					reader.onload = setabi;
-					break;
-				case 'wasm':
-					reader.onload = setcode;
-					break;
-				default:
-					console.error('Unsupported file type');
-					return;
-			}
-			reader.readAsArrayBuffer(file);
+	function set(file: File) {
+		const reader = new FileReader();
+		const extension = file.name.split('.').pop();
+		switch (extension) {
+			case 'abi':
+				reader.onload = setabi;
+				break;
+			case 'wasm':
+				reader.onload = setcode;
+				break;
+			default:
+				console.error('Unsupported file type');
+				return;
 		}
+		reader.readAsArrayBuffer(file);
 	}
 
 	function setabi(this: FileReader) {
@@ -114,39 +112,24 @@
 				the currently logged in account.
 			</p>
 
-			<fieldset class="grid gap-2">
-				<Label for="account-input">{m.common_account_name()}</Label>
-				<NameInput
-					autofocus
-					bind:this={accountInput}
-					bind:ref={accountRef}
-					bind:value={accountName}
-					bind:valid={accountValid}
-					id="account-input"
-					placeholder={m.common_account_name()}
-				/>
-			</fieldset>
+			<NameInput
+				label={m.common_account_name()}
+				bind:this={accountInput}
+				bind:ref={accountRef}
+				bind:value={accountName}
+				bind:valid={accountValid}
+				id="account-input"
+				placeholder={m.common_account_name()}
+			/>
 
 			<fieldset class="grid gap-2">
 				<Label for="account-input">Contract Files</Label>
-				<div
-					class="border-outline focus-within:border-primary focus-within:ring-primary relative flex h-12 gap-2 rounded-lg border-2 px-4 *:content-center focus-within:ring-1 focus-within:ring-inset"
-				>
-					<input
-						type="file"
-						accept=".abi,.wasm"
-						multiple
-						onchange={set}
-						class="placeholder:text-muted w-full rounded-lg bg-transparent font-medium focus:outline-hidden"
-					/>
-				</div>
+				<FileUpload multiple accept=".abi,.wasm" onAccept={set} />
 			</fieldset>
 
 			<Button onclick={transact} disabled={actions.length === 0}>Upload</Button>
 
-			{#if actions.length === 0}
-				<p class="text-muted">Upload files to generate actions.</p>
-			{:else}
+			{#if actions.length > 0}
 				<h3 class="h3">Actions</h3>
 				<p>The actions that will be performed are listed below.</p>
 				{#each actions as action, index}

--- a/src/routes/[network]/(account)/upload/[[name]]/+page.ts
+++ b/src/routes/[network]/(account)/upload/[[name]]/+page.ts
@@ -5,7 +5,7 @@ export const load: PageLoad = async ({ params }) => {
 	return {
 		name: params.name,
 		title: 'Upload Smart Contract',
-		subtitle: 'Upload a smart contract by selecting the ABI and WASM files from your computer.',
+		subtitle: `Select the ABI and WASM files to upload for ${params.name}`,
 		pageMetaTags: {
 			title: 'Upload Smart Contract',
 			description: 'Upload a smart contract by selecting the ABI and WASM files from your computer.'


### PR DESCRIPTION
Closes #452 

Adds the `melt` package which is the next version of melt built with Runes. Not all components are ported over yet, so we can't replace the existing `melt-ui/svelte` package. The file upload component doesn't exist in the old library.